### PR TITLE
chore: update PR title renaming logic to handle both 'main' and 'Main…

### DIFF
--- a/.github/workflows/auto-pr-title.yml
+++ b/.github/workflows/auto-pr-title.yml
@@ -10,15 +10,14 @@ permissions:
 jobs:
   rename-pr:
     name: Rename dev->main PR
-    if: ${{ github.event.pull_request.base.ref == 'main' && github.event.pull_request.head.ref == 'dev' }}
+    if: ${{ (github.event.pull_request.base.ref == 'main' || github.event.pull_request.base.ref == 'Main') && (github.event.pull_request.head.ref == 'dev' || github.event.pull_request.head.ref == 'Dev') }}
     runs-on: ubuntu-latest
     steps:
       - name: Update PR title
         uses: actions/github-script@v7
         with:
           script: |
-            const desiredTitle =
-              "feat: SEO canonical/indexing cleanup (slug redirects, noindex params, sitemap hygiene)";
+            const desiredTitle = "chore: merge dev into main";
             const pull_number = context.payload.pull_request.number;
             const owner = context.repo.owner;
             const repo = context.repo.repo;


### PR DESCRIPTION
…' branches