### PR TITLE
feat: enlarge OG image composition and speed up hero backdrop loading

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -16,6 +16,9 @@ const nextConfig: NextConfig = {
     ];
   },
   images: {
+    // 60 is used for hero backdrops, which sit under heavy gradient
+    // overlays, so the lower quality is invisible but saves bytes.
+    qualities: [60, 75],
     remotePatterns: [
       {
         protocol: "https",

--- a/src/app/(frontend)/(home)/_components/hero/hero-parallax.tsx
+++ b/src/app/(frontend)/(home)/_components/hero/hero-parallax.tsx
@@ -45,6 +45,7 @@ const HeroParallax: React.FC<HeroParallaxProps> = ({
             alt={alt}
             fill
             sizes="100vw"
+            quality={60}
             className="object-cover"
             priority
           />

--- a/src/app/(frontend)/(home)/_components/hero/index.tsx
+++ b/src/app/(frontend)/(home)/_components/hero/index.tsx
@@ -150,8 +150,11 @@ const Hero: React.FC<HeroProps> = ({ screening }) => {
       <h1 className="sr-only">
         Seanse specjalne i stare filmy w kinach studyjnych w Polsce
       </h1>
+      {/* w1280 instead of original: TMDB originals are multi-MB and slow
+          down the optimizer fetch; the backdrop sits under a heavy
+          gradient + grain so the smaller source is indistinguishable. */}
       <HeroParallax
-        backdropSrc={tmdbImageUrl(screening.movie.backdropUrl ?? "", "original")}
+        backdropSrc={tmdbImageUrl(screening.movie.backdropUrl ?? "", "w1280")}
         alt={screening.movie.title}
       >
         <HeroNav />

--- a/src/app/(frontend)/filmy/[slug]/_components/movie-hero.tsx
+++ b/src/app/(frontend)/filmy/[slug]/_components/movie-hero.tsx
@@ -43,11 +43,15 @@ const MovieHero: React.FC<MovieHeroProps> = ({ movie }) => {
             animate={{ opacity: 1, scale: 1 }}
             transition={{ duration: 0.8, ease: [0.22, 1, 0.36, 1] }}
           >
+            {/* w1280 instead of original: TMDB originals are multi-MB and
+                slow down the optimizer fetch; the backdrop sits under a
+                heavy gradient + grain so the smaller source is fine. */}
             <Image
-              src={tmdbImageUrl(movie.backdropUrl, "original")}
+              src={tmdbImageUrl(movie.backdropUrl, "w1280")}
               alt={movie.title}
               fill
               sizes="100vw"
+              quality={60}
               className="object-cover"
               priority
             />

--- a/src/app/(frontend)/lib/og-image.tsx
+++ b/src/app/(frontend)/lib/og-image.tsx
@@ -13,11 +13,14 @@ interface OgImageOptions {
   posterUrl?: string | null;
 }
 
+// Sized so text stays legible when scaled down to small link embeds
+// (Discord/Slack render OG images at roughly 440px wide).
 const getTitleSize = (title: string, hasPoster: boolean): number => {
   const base = hasPoster ? 0.82 : 1;
-  if (title.length > 24) return Math.round(58 * base);
-  if (title.length > 14) return Math.round(76 * base);
-  return Math.round(104 * base);
+  if (title.length > 24) return Math.round(72 * base);
+  if (title.length > 14) return Math.round(96 * base);
+  if (title.length > 9) return Math.round(112 * base);
+  return Math.round(136 * base);
 };
 
 export async function buildOgImage({
@@ -65,12 +68,12 @@ export async function buildOgImage({
             }}
           >
             <div style={{ display: "flex", alignItems: "center", gap: 14 }}>
-              <svg width="30" height="21" viewBox="0 0 28 20">
+              <svg width="34" height="24" viewBox="0 0 28 20">
                 <polygon points="0,8 28,0 28,20 0,12" fill="#ffffff" />
               </svg>
               <span
                 style={{
-                  fontSize: 32,
+                  fontSize: 36,
                   fontWeight: 700,
                   letterSpacing: "-0.02em",
                 }}
@@ -81,10 +84,10 @@ export async function buildOgImage({
             {eyebrow && (
               <span
                 style={{
-                  fontSize: 17,
+                  fontSize: 20,
                   textTransform: "uppercase",
                   letterSpacing: "0.3em",
-                  color: "rgba(255,255,255,0.4)",
+                  color: "rgba(255,255,255,0.45)",
                 }}
               >
                 {eyebrow}
@@ -116,11 +119,11 @@ export async function buildOgImage({
             {subtitle && (
               <span
                 style={{
-                  marginTop: 24,
-                  fontSize: 26,
-                  color: "rgba(255,255,255,0.55)",
-                  lineHeight: 1.4,
-                  maxWidth: 920,
+                  marginTop: 28,
+                  fontSize: 34,
+                  color: "rgba(255,255,255,0.6)",
+                  lineHeight: 1.35,
+                  maxWidth: 980,
                 }}
               >
                 {subtitle}
@@ -140,15 +143,15 @@ export async function buildOgImage({
           >
             <span
               style={{
-                fontSize: 16,
+                fontSize: 19,
                 textTransform: "uppercase",
                 letterSpacing: "0.3em",
-                color: "rgba(255,255,255,0.4)",
+                color: "rgba(255,255,255,0.45)",
               }}
             >
               klaps.space
             </span>
-            <span style={{ fontSize: 24, color: "rgba(255,255,255,0.4)" }}>
+            <span style={{ fontSize: 28, color: "rgba(255,255,255,0.45)" }}>
               →
             </span>
           </div>

--- a/src/app/opengraph-image.tsx
+++ b/src/app/opengraph-image.tsx
@@ -1,93 +1,15 @@
-import { ImageResponse } from "next/og";
+import { buildOgImage, OG_SIZE } from "@/lib/og-image";
 
-export const alt = "Klaps - Repertuar seansów specjalnych i klasyki filmowej";
-export const size = { width: 1200, height: 630 };
+export const size = OG_SIZE;
 export const contentType = "image/png";
+export const alt = "Klaps - Seanse specjalne i klasyka filmowa w kinach studyjnych";
 
-const OgImage = () => {
-  return new ImageResponse(
-    (
-      <div
-        style={{
-          width: "100%",
-          height: "100%",
-          display: "flex",
-          flexDirection: "column",
-          alignItems: "center",
-          justifyContent: "center",
-          backgroundColor: "#000000",
-          position: "relative",
-        }}
-      >
-        <div
-          style={{
-            position: "absolute",
-            top: 0,
-            left: 0,
-            right: 0,
-            height: "4px",
-            background:
-              "linear-gradient(to right, transparent, #dc1301, transparent)",
-          }}
-        />
-
-        <div
-          style={{
-            position: "absolute",
-            bottom: 0,
-            left: 0,
-            right: 0,
-            height: "4px",
-            background:
-              "linear-gradient(to right, transparent, #dc1301, transparent)",
-          }}
-        />
-
-        <div
-          style={{
-            display: "flex",
-            flexDirection: "column",
-            alignItems: "center",
-            gap: "20px",
-          }}
-        >
-          <span
-            style={{
-              fontSize: "96px",
-              fontWeight: 700,
-              color: "#dc1301",
-              letterSpacing: "0.1em",
-              textTransform: "uppercase",
-            }}
-          >
-            Klaps
-          </span>
-
-          <div
-            style={{
-              width: "120px",
-              height: "2px",
-              backgroundColor: "#dc1301",
-            }}
-          />
-
-          <span
-            style={{
-              fontSize: "28px",
-              color: "#a3a3a3",
-              letterSpacing: "0.2em",
-              textTransform: "uppercase",
-              textAlign: "center",
-              maxWidth: "700px",
-            }}
-          >
-            Klasyka kina. Lokalnie.
-          </span>
-        </div>
-      </div>
-    ),
-    { ...size }
-  );
-};
-
-export default OgImage;
+// Root fallback for any route without its own opengraph-image,
+// kept in sync with the (home) variant.
+export default function OgImage() {
+  return buildOgImage({
+    eyebrow: "Kina studyjne w Polsce",
+    title: "Klaps",
+    subtitle: "Seanse specjalne i klasyka filmowa w kinach studyjnych w Polsce",
+  });
+}


### PR DESCRIPTION
## Summary

- Enlarged the OG image composition (bigger title tiers 136/112/96/72px, subtitle 26 -> 34px, bigger eyebrow/footer/logo) so text stays legible in small link embeds (Discord/Slack render at ~440px wide)
- Rewrote the root `src/app/opengraph-image.tsx` fallback to use the shared `buildOgImage` builder, removing the stale red design from the previous site version
- Hero backdrops (homepage + movie page) now load TMDB `w1280` instead of `original` (~6x smaller source, e.g. 788KB -> 132KB) with `quality={60}`, invisible under the heavy gradient + grain overlays
- Added `images.qualities: [60, 75]` to `next.config.ts` (required by Next 16 for non-default quality)

## Test plan

- [x] `tsc --noEmit` and `eslint` clean
- [x] Verified rendered OG images on dev server (short, long and homepage title variants)
- [x] Verified homepage srcset requests `w1280` source with `q=60`

🤖 Generated with [Claude Code](https://claude.com/claude-code)