### PR TITLE
feat: improve AI Overviews eligibility with snippet, ItemList and freshness signals

### DIFF
--- a/src/app/(frontend)/gatunki/[slug]/layout.tsx
+++ b/src/app/(frontend)/gatunki/[slug]/layout.tsx
@@ -15,6 +15,9 @@ const buildGenreJsonLd = (genre: IGenre, movies: readonly IMovieSummary[]) => ({
   name: `${genre.name} - Filmy`,
   url: `${SITE_URL}/gatunki/${genre.slug}`,
   description: `Filmy z gatunku ${genre.name.toLowerCase()} dostępne w serwisie Klaps.`,
+  // Freshness signal for AI Overviews: render time equals the moment
+  // the movie data was last refreshed (ISR).
+  dateModified: new Date().toISOString(),
   mainEntity: {
     "@type": "ItemList",
     numberOfItems: movies.length,

--- a/src/app/(frontend)/kina/layout.tsx
+++ b/src/app/(frontend)/kina/layout.tsx
@@ -14,6 +14,9 @@ const buildCinemasJsonLd = (cinemaGroups: readonly ICinemaGroup[]) => {
     url: `${SITE_URL}/kina`,
     description:
       "Pełna lista kin studyjnych i niezależnych w Polsce wraz z repertuarem seansów specjalnych.",
+    // Freshness signal for AI Overviews: render time equals the moment
+    // the cinema data was last refreshed (ISR).
+    dateModified: new Date().toISOString(),
     mainEntity: {
       "@type": "ItemList",
       numberOfItems: cinemas.length,

--- a/src/app/(frontend)/lib/seo.ts
+++ b/src/app/(frontend)/lib/seo.ts
@@ -32,6 +32,15 @@ export const pluralPl = (
   return many;
 };
 
+/** Date in Polish long form, e.g. "7 czerwca 2026". Used for the visible
+ * "repertoire updated" note that mirrors dateModified in JSON-LD. */
+export const formatPlDate = (date: Date): string =>
+  new Intl.DateTimeFormat("pl-PL", {
+    day: "numeric",
+    month: "long",
+    year: "numeric",
+  }).format(date);
+
 /** Query params that change the visible result set on listing pages. */
 export const SCREENING_FILTER_PARAM_KEYS = [
   "city",

--- a/src/app/(frontend)/miasta/[slug]/layout.tsx
+++ b/src/app/(frontend)/miasta/[slug]/layout.tsx
@@ -2,6 +2,7 @@ import { getCityBySlug } from "@/lib/cities";
 import { getCinemas } from "@/lib/cinemas";
 import { SITE_URL } from "@/lib/site-config";
 import { ICity } from "@/interfaces/ICities";
+import { IScreeningGroup } from "@/interfaces/IScreenings";
 import JsonLd from "@/components/common/json-ld";
 
 type CityLayoutProps = {
@@ -12,13 +13,29 @@ type CityLayoutProps = {
 const buildCityJsonLd = (
   city: ICity,
   cinemasCount: number,
-  screeningsCount: number
+  screeningsCount: number,
+  screeningGroups: IScreeningGroup[]
 ) => ({
   "@context": "https://schema.org",
   "@type": "CollectionPage",
   name: `Kina i seanse w ${city.nameDeclinated}`,
   url: `${SITE_URL}/miasta/${city.slug}`,
   description: `${cinemasCount} kin i ${screeningsCount} seansów specjalnych w ${city.nameDeclinated}.`,
+  // Freshness signal for AI Overviews: render time equals the moment
+  // the repertoire data was last refreshed (ISR).
+  dateModified: new Date().toISOString(),
+  // The visible repertoire mirrored as an ItemList, so AI search gets
+  // a machine-readable "what's playing in this city" list.
+  mainEntity: {
+    "@type": "ItemList",
+    numberOfItems: screeningGroups.length,
+    itemListElement: screeningGroups.map((group, index) => ({
+      "@type": "ListItem",
+      position: index + 1,
+      url: `${SITE_URL}/filmy/${group.movie.slug}`,
+      name: `${group.movie.title} (${group.movie.productionYear})`,
+    })),
+  },
 });
 
 export default async function CityLayout({
@@ -44,7 +61,9 @@ export default async function CityLayout({
 
   return (
     <>
-      <JsonLd data={buildCityJsonLd(city, cinemasCount, screeningsCount)} />
+      <JsonLd
+        data={buildCityJsonLd(city, cinemasCount, screeningsCount, screenings)}
+      />
       {children}
     </>
   );

--- a/src/app/(frontend)/miasta/[slug]/page.tsx
+++ b/src/app/(frontend)/miasta/[slug]/page.tsx
@@ -6,7 +6,12 @@ import { getCinemas } from "@/lib/cinemas";
 import { getGenres } from "@/lib/genres";
 import { getScreenings } from "@/lib/screenings";
 import { SITE_URL } from "@/lib/site-config";
-import { BASE_OPEN_GRAPH, NOINDEX_FOLLOW, pluralPl } from "@/lib/seo";
+import {
+  BASE_OPEN_GRAPH,
+  NOINDEX_FOLLOW,
+  formatPlDate,
+  pluralPl,
+} from "@/lib/seo";
 import Breadcrumbs from "@/components/ui/breadcrumbs";
 import PageHeading from "@/components/ui/page-heading";
 import SiteHeader from "@/components/common/site-header";
@@ -145,6 +150,12 @@ const CityPage = async ({ params }: CityPageProps) => {
               i&nbsp;klasykę filmową na dużym ekranie.
             </p>
           )
+        )}
+        {cinemasCount > 0 && (
+          // Visible freshness signal, mirrors dateModified in JSON-LD.
+          <p className="mt-5 text-[10px] md:text-xs uppercase tracking-[0.25em] text-white/35">
+            Repertuar zaktualizowano: {formatPlDate(new Date())}
+          </p>
         )}
       </header>
 

--- a/src/app/(frontend)/miasta/layout.tsx
+++ b/src/app/(frontend)/miasta/layout.tsx
@@ -17,6 +17,9 @@ const buildCitiesJsonLd = (cinemaGroups: readonly ICinemaGroup[]) => {
     url: `${SITE_URL}/miasta`,
     description:
       "Miasta w Polsce z kinami studyjnymi i repertuarem seansów specjalnych.",
+    // Freshness signal for AI Overviews: render time equals the moment
+    // the city data was last refreshed (ISR).
+    dateModified: new Date().toISOString(),
     mainEntity: {
       "@type": "ItemList",
       numberOfItems: cities.length,

--- a/src/app/(frontend)/seanse/page.tsx
+++ b/src/app/(frontend)/seanse/page.tsx
@@ -14,7 +14,12 @@ import { getPreferredCityId } from "@/lib/get-preferred-city";
 import { IScreeningGroup } from "@/interfaces/IScreenings";
 import { PaginatedResponse } from "@/interfaces/IMovies";
 import { SITE_URL } from "@/lib/site-config";
-import { BASE_OPEN_GRAPH, NOINDEX_FOLLOW, hasFilterParams } from "@/lib/seo";
+import {
+  BASE_OPEN_GRAPH,
+  NOINDEX_FOLLOW,
+  formatPlDate,
+  hasFilterParams,
+} from "@/lib/seo";
 import ScreeningsPageSection from "./_components/screenings-page-section";
 import ScreeningsPageLoader from "./_components/screenings-page-loader";
 
@@ -148,34 +153,51 @@ const ScreeningsListing = async ({ params }: { params: SearchParams }) => {
   const genres = await getGenres();
 
   return (
-    <ScreeningsPageSection
-      screenings={screenings}
-      genres={genres}
-      selectedGenreIds={genreIds.map(Number)}
-      dateFrom={params.dateFrom ?? null}
-      dateTo={params.dateTo ?? null}
-      search={params.search ?? null}
-      currentPage={currentPage}
-      totalPages={totalPages}
-    />
+    <>
+      <JsonLd data={buildScreeningsJsonLd(screenings)} />
+      <ScreeningsPageSection
+        screenings={screenings}
+        genres={genres}
+        selectedGenreIds={genreIds.map(Number)}
+        dateFrom={params.dateFrom ?? null}
+        dateTo={params.dateTo ?? null}
+        search={params.search ?? null}
+        currentPage={currentPage}
+        totalPages={totalPages}
+      />
+    </>
   );
 };
 
-const SCREENINGS_JSONLD = {
+// CollectionPage with the visible movie list mirrored as an ItemList,
+// so AI search results get a machine-readable "what's playing" list.
+// dateModified reflects the render time, i.e. when the repertoire data
+// was last refreshed (freshness signal for AI Overviews).
+const buildScreeningsJsonLd = (screenings: IScreeningGroup[]) => ({
   "@context": "https://schema.org",
   "@type": "CollectionPage",
   name: "Seanse specjalne w kinach studyjnych - repertuar",
   url: `${SITE_URL}/seanse`,
   description:
     "Aktualna lista seansów specjalnych, retrospektyw i klasyki filmowej w kinach studyjnych w całej Polsce.",
-};
+  dateModified: new Date().toISOString(),
+  mainEntity: {
+    "@type": "ItemList",
+    numberOfItems: screenings.length,
+    itemListElement: screenings.map((group, index) => ({
+      "@type": "ListItem",
+      position: index + 1,
+      url: `${SITE_URL}/filmy/${group.movie.slug}`,
+      name: `${group.movie.title} (${group.movie.productionYear})`,
+    })),
+  },
+});
 
 const ScreeningsPage = async ({ searchParams }: ScreeningsPageProps) => {
   const params = await searchParams;
 
   return (
     <main className="bg-black text-white min-h-screen">
-      <JsonLd data={SCREENINGS_JSONLD} />
       <SiteHeader />
 
       <div className="px-6 md:px-12 lg:px-16 pt-8 md:pt-10 pb-4">
@@ -208,6 +230,10 @@ const ScreeningsPage = async ({ searchParams }: ScreeningsPageProps) => {
             miast
           </Link>
           .
+        </p>
+        {/* Visible freshness signal, mirrors dateModified in JSON-LD. */}
+        <p className="mt-5 text-[10px] md:text-xs uppercase tracking-[0.25em] text-white/35">
+          Repertuar zaktualizowano: {formatPlDate(new Date())}
         </p>
       </header>
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -45,7 +45,9 @@ export const metadata: Metadata = {
     googleBot: {
       index: true,
       follow: true,
-      "max-snippet": 160,
+      // Unlimited snippet length: Google applies this limit to AI Overviews
+      // and AI Mode citations as well, so capping it hurts GEO/AEO.
+      "max-snippet": -1,
       "max-image-preview": "large",
       "max-video-preview": -1,
     },


### PR DESCRIPTION
## Summary

Improves the site's eligibility for Google AI Overviews (GEO/AEO) with three changes:

- **Lift the `max-snippet` limit (160 to -1)** in the root layout. Google applies snippet controls to AI Overviews and AI Mode citations as well, so the 160-character cap limited how much of the page Google could quote.
- **ItemList JSON-LD on repertoire listings.** `/seanse` and `/miasta/[slug]` now mirror the visible movie list as a `mainEntity: ItemList` inside the existing `CollectionPage`, giving AI search a machine-readable "what's playing" list. (`/kina`, `/miasta` and `/gatunki/[slug]` already had one.)
- **Freshness signals.** `dateModified` (render time, i.e. when ISR last refreshed the data) added to `CollectionPage` JSON-LD on all listing pages, plus a visible "Repertuar zaktualizowano" note on `/seanse` and city pages so structured data matches on-page content.

Also adds a small `formatPlDate` helper to `lib/seo.ts` for Polish long-form dates.

## Test plan

- `tsc --noEmit` and `eslint` pass (one pre-existing unrelated warning in `cinemas.ts`)
- Verify `/seanse` and a city page render the update date under the header
- Validate JSON-LD on `/seanse` and `/miasta/[slug]` with the Rich Results Test (ItemList + dateModified present)
