### PR TITLE
feat: real repertoire freshness, voivodeship and copy polish

### DIFF
--- a/src/app/(frontend)/(home)/_components/footer/index.tsx
+++ b/src/app/(frontend)/(home)/_components/footer/index.tsx
@@ -110,8 +110,8 @@ const Footer: React.FC = () => {
           <Image src="/tmdb-logo.svg" alt="TMDB" width={60} height={8} />
         </a>
         <p>
-          Dane filmowe dostarcza TMDB. Serwis nie jest powiązany
-          z&nbsp;TMDB.
+          Korzystamy z&nbsp;API TMDB, ale nie jesteśmy przez TMDB wspierani
+          ani certyfikowani.
         </p>
       </div>
     </footer>

--- a/src/app/(frontend)/(home)/_components/hero/text-reveal.tsx
+++ b/src/app/(frontend)/(home)/_components/hero/text-reveal.tsx
@@ -46,9 +46,11 @@ export const TitleReveal: React.FC<TitleRevealProps> = ({
     // sr-only h1 in the hero carries the page's main heading instead.
     <motion.h2 className={className} variants={wordRevealContainer}>
       {words.map((word, i) => (
+        // Top padding + matching negative margin keep the slide-up mask
+        // from clipping tall diacritics (Ś, Ć, Ó) without shifting layout.
         <span
           key={`${word}-${i}`}
-          className="inline-block overflow-hidden pb-[0.08em] mr-[0.25em] align-bottom"
+          className="inline-block overflow-hidden pt-[0.2em] -mt-[0.2em] pb-[0.08em] mr-[0.25em] align-bottom"
         >
           <motion.span className="inline-block" variants={wordRevealItem}>
             {word}

--- a/src/app/(frontend)/filmy/[slug]/_components/movie-screenings.tsx
+++ b/src/app/(frontend)/filmy/[slug]/_components/movie-screenings.tsx
@@ -41,24 +41,9 @@ const formatShortDate = (dateStr: string): string =>
     month: "2-digit",
   });
 
+// We do not sell tickets or broker reservations, so the time is plain
+// text and never links out to a booking page.
 const ScreeningTime: React.FC<ScreeningTimeProps> = ({ screening }) => {
-  if (screening.ticketUrl) {
-    return (
-      <a
-        href={screening.ticketUrl}
-        target="_blank"
-        rel="noreferrer noopener nofollow"
-        className="group/time flex flex-col items-center gap-1.5"
-      >
-        <span className="text-2xl md:text-3xl font-semibold tabular-nums -tracking-[0.01em] text-white underline underline-offset-8 decoration-2 decoration-white/30 group-hover/time:decoration-white transition-colors">
-          {screening.time}
-        </span>
-        <span className="text-[10px] uppercase tracking-[0.2em] tabular-nums text-white/45">
-          {formatShortDate(screening.date)}
-        </span>
-      </a>
-    );
-  }
   return (
     <span className="flex flex-col items-center gap-1.5 cursor-default">
       <span className="text-2xl md:text-3xl font-semibold tabular-nums -tracking-[0.01em] text-white/80">
@@ -119,11 +104,8 @@ const CinemaRow: React.FC<CinemaRowProps> = ({
     fileName: `${movieSlug}-${screening.date}-${screening.time.replace(":", "")}.ics`,
     description: [
       `Seans filmu "${movieTitle}" w ${first.cinema.name}, ${first.cinema.city.name}.`,
-      screening.ticketUrl ? `Bilety: ${screening.ticketUrl}` : null,
       `Szczegóły: ${movieUrl}`,
-    ]
-      .filter(Boolean)
-      .join("\n"),
+    ].join("\n"),
   }));
 
   return (

--- a/src/app/(frontend)/filmy/[slug]/layout.tsx
+++ b/src/app/(frontend)/filmy/[slug]/layout.tsx
@@ -86,7 +86,6 @@ const buildMovieScreeningEvents = (movie: IMovie, screenings: IScreening[]) =>
         cityName: screening.cinema.city.name,
       },
       dateTime: screening.dateTime,
-      ticketUrl: screening.ticketUrl,
     })),
     `${SITE_URL}/filmy/${movie.slug}`
   );

--- a/src/app/(frontend)/gatunki/[slug]/_components/genre-repertoire/index.tsx
+++ b/src/app/(frontend)/gatunki/[slug]/_components/genre-repertoire/index.tsx
@@ -76,7 +76,7 @@ const GenreRepertoireInner: React.FC<GenreRepertoireProps> = ({
       <div className="mb-10 md:mb-12">
         <FilterBar genres={genres} hideGenres />
         <div
-          className="mt-4 md:mt-5 -mx-6 md:-mx-12 lg:-mx-16 h-px bg-white/10"
+          className="mt-8 md:mt-12 -mx-6 md:-mx-12 lg:-mx-16 h-px bg-white/10"
           aria-hidden="true"
         />
       </div>

--- a/src/app/(frontend)/gatunki/[slug]/page.tsx
+++ b/src/app/(frontend)/gatunki/[slug]/page.tsx
@@ -107,7 +107,7 @@ const GenrePage = async ({ params }: GenrePageProps) => {
         />
       </div>
 
-      <header className="px-6 md:px-12 lg:px-16 pt-6 md:pt-8 pb-12 md:pb-16">
+      <header className="px-6 md:px-12 lg:px-16 pt-6 md:pt-8 pb-8 md:pb-12">
         <PageHeading variant="detail" className="max-w-[20ch]">
           Filmy z&nbsp;gatunku {genreNameLower}
         </PageHeading>

--- a/src/app/(frontend)/interfaces/IScreenings.ts
+++ b/src/app/(frontend)/interfaces/IScreenings.ts
@@ -6,7 +6,6 @@ export interface IScreening {
   date: string;
   time: string;
   dateTime: string;
-  ticketUrl: string | null;
   isDubbing: boolean;
   isSubtitled: boolean;
   cinema: ICinemaSummary;

--- a/src/app/(frontend)/kina/[slug]/_components/cinema-repertoire/index.tsx
+++ b/src/app/(frontend)/kina/[slug]/_components/cinema-repertoire/index.tsx
@@ -49,15 +49,15 @@ const CinemaRepertoireInner: React.FC<CinemaRepertoireProps> = ({
   );
 
   return (
-    <section className="border-t border-white/10 px-6 md:px-12 lg:px-16 pt-12 md:pt-16 pb-20 md:pb-28">
-      <h2 className="mb-8 md:mb-10 text-2xl md:text-4xl lg:text-5xl leading-[1.05] -tracking-[0.02em] max-w-[26ch] text-white font-medium">
+    <section className="border-t border-white/10 px-6 md:px-12 lg:px-16 pt-8 md:pt-12 pb-20 md:pb-28">
+      <h2 className="mb-6 md:mb-8 text-2xl md:text-4xl lg:text-5xl leading-[1.05] -tracking-[0.02em] max-w-[26ch] text-white font-medium">
         Repertuar kina {cinemaName}
       </h2>
 
       <div className="mb-10 md:mb-12">
         <FilterBar genres={genres} hideCity />
         <div
-          className="mt-4 md:mt-5 -mx-6 md:-mx-12 lg:-mx-16 h-px bg-white/10"
+          className="mt-8 md:mt-12 -mx-6 md:-mx-12 lg:-mx-16 h-px bg-white/10"
           aria-hidden="true"
         />
       </div>

--- a/src/app/(frontend)/kina/[slug]/layout.tsx
+++ b/src/app/(frontend)/kina/[slug]/layout.tsx
@@ -63,7 +63,6 @@ const buildCinemaScreeningEvents = (
           longitude: cinema.longitude,
         },
         dateTime: screening.dateTime,
-        ticketUrl: screening.ticketUrl,
       }))
     ),
     `${SITE_URL}/kina/${cinema.slug}`

--- a/src/app/(frontend)/kina/[slug]/page.tsx
+++ b/src/app/(frontend)/kina/[slug]/page.tsx
@@ -142,29 +142,32 @@ const CinemaPageContent = async ({ slug }: { slug: string }) => {
             <PageHeading variant="detail" className="max-w-[20ch]">
               {cinema.name}
             </PageHeading>
-            <div className="mt-4 md:mt-5 flex flex-wrap items-baseline gap-x-4 gap-y-1 text-[10px] md:text-xs uppercase tracking-[0.22em] text-white/45">
-              <span>
-                {cinema.street && <>{cinema.street}, </>}
-                <Link
-                  href={`/miasta/${cinema.city.slug}`}
-                  className="text-white/70 hover:text-white transition-colors border-b border-transparent hover:border-white/40 pb-0.5"
-                >
-                  {cinema.city.name}
-                </Link>
-              </span>
-              {cinema.sourceUrl && (
-                <>
-                  <span aria-hidden="true">·</span>
+            <div className="mt-4 md:mt-5 flex flex-col gap-1.5 text-[10px] md:text-xs uppercase tracking-[0.22em] text-white/45">
+              {cinema.street && <span>{cinema.street}</span>}
+              <span className="flex flex-wrap items-baseline gap-x-3 gap-y-1">
+                <span>
                   <Link
-                    href={cinema.sourceUrl}
-                    target="_blank"
-                    rel="noreferrer noopener nofollow"
+                    href={`/miasta/${cinema.city.slug}`}
                     className="text-white/70 hover:text-white transition-colors border-b border-transparent hover:border-white/40 pb-0.5"
                   >
-                    Strona kina ↗
+                    {cinema.city.name}
                   </Link>
-                </>
-              )}
+                  {cinema.city.voivodeship && <>, {cinema.city.voivodeship}</>}
+                </span>
+                {cinema.sourceUrl && (
+                  <>
+                    <span aria-hidden="true">·</span>
+                    <Link
+                      href={cinema.sourceUrl}
+                      target="_blank"
+                      rel="noreferrer noopener nofollow"
+                      className="text-white/70 hover:text-white transition-colors border-b border-transparent hover:border-white/40 pb-0.5"
+                    >
+                      Strona kina ↗
+                    </Link>
+                  </>
+                )}
+              </span>
             </div>
             {cinema.description ? (
               <p className="mt-8 md:mt-10 max-w-[60ch] text-base md:text-lg text-white/65 leading-relaxed">

--- a/src/app/(frontend)/lib/screening-event-jsonld.ts
+++ b/src/app/(frontend)/lib/screening-event-jsonld.ts
@@ -24,7 +24,6 @@ export interface ScreeningEventData {
   movie: ScreeningEventMovie;
   cinema: ScreeningEventCinema;
   dateTime: string;
-  ticketUrl: string | null;
 }
 
 // Keep the events payload reasonable - soonest screenings first.
@@ -34,7 +33,7 @@ const buildEvent = (
   data: ScreeningEventData,
   pageUrl: string
 ): Record<string, unknown> => {
-  const { movie, cinema, dateTime, ticketUrl } = data;
+  const { movie, cinema, dateTime } = data;
 
   const location: Record<string, unknown> = {
     "@type": "MovieTheater",
@@ -80,14 +79,6 @@ const buildEvent = (
     event.endDate = new Date(
       new Date(dateTime).getTime() + movie.duration * 60 * 1000
     ).toISOString();
-  }
-
-  if (ticketUrl) {
-    event.offers = {
-      "@type": "Offer",
-      url: ticketUrl,
-      availability: "https://schema.org/InStock",
-    };
   }
 
   return event;

--- a/src/app/(frontend)/lib/screenings.ts
+++ b/src/app/(frontend)/lib/screenings.ts
@@ -27,6 +27,14 @@ interface GetMovieScreeningsParams {
   cityId?: string | null;
 }
 
+interface GetLastUpdatedParams {
+  cityId?: string | null;
+  voivodeship?: string | null;
+  citySlug?: string | null;
+  cinemaId?: string | null;
+  cinemaSlug?: string | null;
+}
+
 export const getScreenings = async (
   params: GetScreeningsParams = {}
 ): Promise<IScreeningGroup[]> => {
@@ -101,6 +109,36 @@ export const getPaginatedScreenings = async (
         totalPages: 0,
       },
     };
+  }
+};
+
+/**
+ * Newest screening `updatedAt` for the (optionally location-filtered) set,
+ * i.e. when repertoire data was last added. Backs the visible
+ * "Repertuar zaktualizowano" label and JSON-LD dateModified.
+ * Returns null when nothing matches or the request fails.
+ */
+export const getScreeningsLastUpdated = async (
+  params: GetLastUpdatedParams = {}
+): Promise<Date | null> => {
+  try {
+    const response = await apiFetch<{ updatedAt: string | null }>(
+      "/screenings/last-updated",
+      {
+        params: {
+          cityId: params.cityId ?? "",
+          voivodeship: params.voivodeship ?? "",
+          citySlug: params.citySlug ?? "",
+          cinemaId: params.cinemaId ?? "",
+          cinemaSlug: params.cinemaSlug ?? "",
+        },
+      }
+    );
+
+    return response.updatedAt ? new Date(response.updatedAt) : null;
+  } catch (error) {
+    console.warn("Falling back to null screenings last-updated:", error);
+    return null;
   }
 };
 

--- a/src/app/(frontend)/miasta/[slug]/_components/city-repertoire/index.tsx
+++ b/src/app/(frontend)/miasta/[slug]/_components/city-repertoire/index.tsx
@@ -45,15 +45,15 @@ const CityRepertoireInner: React.FC<CityRepertoireProps> = ({
   );
 
   return (
-    <section className="border-t border-white/10 px-6 md:px-12 lg:px-16 pt-12 md:pt-16 pb-20 md:pb-28">
-      <h2 className="mb-8 md:mb-10 text-2xl md:text-4xl lg:text-5xl leading-[1.05] -tracking-[0.02em] max-w-[26ch] text-white font-medium">
+    <section className="border-t border-white/10 px-6 md:px-12 lg:px-16 pt-8 md:pt-12 pb-20 md:pb-28">
+      <h2 className="mb-6 md:mb-8 text-2xl md:text-4xl lg:text-5xl leading-[1.05] -tracking-[0.02em] max-w-[26ch] text-white font-medium">
         Co gra w&nbsp;{cityForCopy}
       </h2>
 
       <div className="mb-10 md:mb-12">
         <FilterBar genres={genres} hideCity />
         <div
-          className="mt-4 md:mt-5 -mx-6 md:-mx-12 lg:-mx-16 h-px bg-white/10"
+          className="mt-8 md:mt-12 -mx-6 md:-mx-12 lg:-mx-16 h-px bg-white/10"
           aria-hidden="true"
         />
       </div>

--- a/src/app/(frontend)/miasta/[slug]/page.tsx
+++ b/src/app/(frontend)/miasta/[slug]/page.tsx
@@ -4,7 +4,7 @@ import { Metadata } from "next";
 import { getCityBySlug } from "@/lib/cities";
 import { getCinemas } from "@/lib/cinemas";
 import { getGenres } from "@/lib/genres";
-import { getScreenings } from "@/lib/screenings";
+import { getScreenings, getScreeningsLastUpdated } from "@/lib/screenings";
 import { SITE_URL } from "@/lib/site-config";
 import {
   BASE_OPEN_GRAPH,
@@ -99,11 +99,13 @@ const CityPage = async ({ params }: CityPageProps) => {
 
   // Full unfiltered repertoire - CityRepertoire narrows it down
   // client-side based on the URL params.
-  const [{ data: cinemaGroups }, allGenres, screenings] = await Promise.all([
-    getCinemas({ cityId: city.id.toString() }),
-    getGenres(),
-    getScreenings({ cityId: city.id.toString() }),
-  ]);
+  const [{ data: cinemaGroups }, allGenres, screenings, lastUpdated] =
+    await Promise.all([
+      getCinemas({ cityId: city.id.toString() }),
+      getGenres(),
+      getScreenings({ cityId: city.id.toString() }),
+      getScreeningsLastUpdated({ cityId: city.id.toString() }),
+    ]);
 
   const cinemas = cinemaGroups
     .flatMap((g) => g.cinemas)
@@ -159,9 +161,9 @@ const CityPage = async ({ params }: CityPageProps) => {
           )
         )}
         {cinemasCount > 0 && (
-          // Visible freshness signal, mirrors dateModified in JSON-LD.
+          // Visible freshness signal: newest screening updatedAt for this city.
           <p className="mt-5 text-[10px] md:text-xs uppercase tracking-[0.25em] text-white/35">
-            Repertuar zaktualizowano: {formatPlDate(new Date())}
+            Repertuar zaktualizowano: {formatPlDate(lastUpdated ?? new Date())}
           </p>
         )}
       </header>

--- a/src/app/(frontend)/o-projekcie/page.tsx
+++ b/src/app/(frontend)/o-projekcie/page.tsx
@@ -22,7 +22,7 @@ const MANIFESTO: ManifestoItem[] = [
   {
     n: "01",
     title: "Niezależność",
-    body: "Bez reklam, bez algorytmów rekomendujących, bez rankingów. Treści nie są promowane komercyjnie ani wartościowane liczbami.",
+    body: "Bez reklam i bez płatnych wyróżnień. Żaden seans nie trafia wyżej dlatego, że ktoś za to zapłacił.",
   },
   {
     n: "02",
@@ -32,7 +32,7 @@ const MANIFESTO: ManifestoItem[] = [
   {
     n: "03",
     title: "Cała Polska",
-    body: "Repertuar kin studyjnych z każdego miasta i wybrane seanse specjalne organizowane przez kina sieciowe. Bez podziału na lepsze i gorsze.",
+    body: "Repertuar kin studyjnych z każdego miasta i wybrane seanse specjalne organizowane przez kina sieciowe. Wielka metropolia czy mała miejscowość, traktujemy je tak samo.",
   },
   {
     n: "04",
@@ -42,7 +42,7 @@ const MANIFESTO: ManifestoItem[] = [
   {
     n: "05",
     title: "Otwartość",
-    body: "Otwarty kod źródłowy, otwarta baza danych, otwarta misja. Bezpłatnie i na zawsze. Klaps należy do widzów, nie do inwestorów.",
+    body: "Otwarty kod źródłowy, otwarta misja. Bezpłatnie i na zawsze. Klaps należy do widzów, nie do inwestorów.",
   },
   {
     n: "06",
@@ -208,11 +208,12 @@ const AboutPage = () => {
           </h2>
           <div className="lg:col-span-8 flex flex-col gap-5 max-w-[68ch] text-base md:text-lg text-white/65 leading-relaxed">
             <p>
-              Repertuar pozyskujemy z&nbsp;publicznie dostępnych źródeł kin,
-              które regularnie organizują pokazy specjalne, retrospektywy
-              i&nbsp;wznowienia. Nie korzystamy z&nbsp;zamkniętych baz danych
-              ani komercyjnych API. Klaps zbiera informacje w&nbsp;jednym
-              miejscu i&nbsp;pokazuje je w&nbsp;ujednoliconej formie.
+              Repertuar agregujemy z&nbsp;publicznie dostępnych źródeł
+              internetowych o&nbsp;pokazach specjalnych, retrospektywach
+              i&nbsp;wznowieniach. Dane o&nbsp;filmach, czyli opisy, oceny
+              i&nbsp;plakaty, pochodzą z&nbsp;TMDB. Klaps zbiera te informacje
+              w&nbsp;jednym miejscu i&nbsp;pokazuje je w&nbsp;ujednoliconej
+              formie.
             </p>
             <p>
               Nie sprzedajemy biletów ani nie pośredniczymy
@@ -258,19 +259,26 @@ const AboutPage = () => {
       </section>
 
       <section className="border-t border-white/10 px-6 md:px-12 lg:px-16 pt-14 md:pt-20 pb-14 md:pb-20">
-        <h2 className="mb-10 md:mb-14 text-3xl md:text-5xl lg:text-6xl leading-[1] -tracking-[0.03em] text-white font-medium">
-          Dla kogo
-        </h2>
-        <ul className="flex flex-col">
-          {AUDIENCE.map((item) => (
-            <li
-              key={item}
-              className="border-t border-white/10 last:border-b py-5 md:py-6 text-xl md:text-2xl lg:text-3xl text-white/85 -tracking-[0.01em] leading-snug"
-            >
-              {item}
-            </li>
-          ))}
-        </ul>
+        <div className="grid grid-cols-1 lg:grid-cols-12 gap-8 lg:gap-12">
+          <h2 className="lg:col-span-4 text-3xl md:text-5xl lg:text-6xl leading-[1] -tracking-[0.03em] text-white font-medium">
+            Dla kogo
+          </h2>
+          <ol className="lg:col-span-8 flex flex-col">
+            {AUDIENCE.map((item, index) => (
+              <li
+                key={item}
+                className="group flex items-baseline gap-5 md:gap-8 border-t border-white/10 last:border-b py-5 md:py-7"
+              >
+                <span className="shrink-0 text-xs md:text-sm tabular-nums text-white/30 leading-none">
+                  {String(index + 1).padStart(2, "0")}
+                </span>
+                <span className="max-w-[42ch] text-lg md:text-2xl text-white/80 group-hover:text-white -tracking-[0.01em] leading-snug transition-colors">
+                  {item}
+                </span>
+              </li>
+            ))}
+          </ol>
+        </div>
       </section>
 
       <section className="border-t border-white/10 px-6 md:px-12 lg:px-16 pt-14 md:pt-20 pb-14 md:pb-20">

--- a/src/app/(frontend)/seanse/page.tsx
+++ b/src/app/(frontend)/seanse/page.tsx
@@ -8,7 +8,10 @@ import PageHeading, {
 } from "@/components/ui/page-heading";
 import SiteHeader from "@/components/common/site-header";
 import Footer from "../(home)/_components/footer";
-import { getPaginatedScreenings } from "@/lib/screenings";
+import {
+  getPaginatedScreenings,
+  getScreeningsLastUpdated,
+} from "@/lib/screenings";
 import { getGenres } from "@/lib/genres";
 import { getPreferredLocation } from "@/lib/get-preferred-city";
 import { IScreeningGroup } from "@/interfaces/IScreenings";
@@ -152,11 +155,16 @@ const ScreeningsListing = async ({ params }: { params: SearchParams }) => {
     currentPage * PAGE_SIZE
   );
 
-  const genres = await getGenres();
+  const [genres, lastUpdated] = await Promise.all([
+    getGenres(),
+    getScreeningsLastUpdated({ cityId, voivodeship }),
+  ]);
 
   return (
     <>
-      <JsonLd data={buildScreeningsJsonLd(screenings)} />
+      <JsonLd
+        data={buildScreeningsJsonLd(screenings, lastUpdated ?? new Date())}
+      />
       <ScreeningsPageSection
         screenings={screenings}
         genres={genres}
@@ -173,16 +181,19 @@ const ScreeningsListing = async ({ params }: { params: SearchParams }) => {
 
 // CollectionPage with the visible movie list mirrored as an ItemList,
 // so AI search results get a machine-readable "what's playing" list.
-// dateModified reflects the render time, i.e. when the repertoire data
-// was last refreshed (freshness signal for AI Overviews).
-const buildScreeningsJsonLd = (screenings: IScreeningGroup[]) => ({
+// dateModified reflects the newest screening's updatedAt, i.e. when the
+// repertoire data was last added (freshness signal for AI Overviews).
+const buildScreeningsJsonLd = (
+  screenings: IScreeningGroup[],
+  dateModified: Date
+) => ({
   "@context": "https://schema.org",
   "@type": "CollectionPage",
   name: "Seanse specjalne w kinach studyjnych - repertuar",
   url: `${SITE_URL}/seanse`,
   description:
     "Aktualna lista seansów specjalnych, retrospektyw i klasyki filmowej w kinach studyjnych w całej Polsce.",
-  dateModified: new Date().toISOString(),
+  dateModified: dateModified.toISOString(),
   mainEntity: {
     "@type": "ItemList",
     numberOfItems: screenings.length,
@@ -197,6 +208,7 @@ const buildScreeningsJsonLd = (screenings: IScreeningGroup[]) => ({
 
 const ScreeningsPage = async ({ searchParams }: ScreeningsPageProps) => {
   const params = await searchParams;
+  const lastUpdated = (await getScreeningsLastUpdated()) ?? new Date();
 
   return (
     <main className="bg-black text-white min-h-screen">
@@ -235,7 +247,7 @@ const ScreeningsPage = async ({ searchParams }: ScreeningsPageProps) => {
         </p>
         {/* Visible freshness signal, mirrors dateModified in JSON-LD. */}
         <p className="mt-5 text-[10px] md:text-xs uppercase tracking-[0.25em] text-white/35">
-          Repertuar zaktualizowano: {formatPlDate(new Date())}
+          Repertuar zaktualizowano: {formatPlDate(lastUpdated)}
         </p>
       </header>
 


### PR DESCRIPTION
## Summary
- Replace render-time "Repertuar zaktualizowano" with the newest screening `updatedAt` (real freshness signal for users and JSON-LD `dateModified` on `/seanse` and city pages).
- Show city voivodeship in the cinema location line.
- Drop `ticketUrl` from screenings everywhere (we never broker tickets): plain-text times, no booking links in ICS or JSON-LD.
- Copy: reworded TMDB attribution and the manifesto/about sections.
- Layout polish: "Dla kogo" as a numbered grid, tighter heading-to-filter spacing, hero word mask padded so tall diacritics (Ś, Ć, Ó) are not clipped.

## Commits
1. `refactor: drop ticketUrl from screenings`
2. `feat: derive repertoire freshness from newest screening and show voivodeship`
3. `style: refine about/footer copy and tighten section spacing`