### PR TITLE
fix: resolve movie-page voivodeship filter from cities list

### DIFF
--- a/src/app/(frontend)/filmy/[slug]/_components/movie-screenings.tsx
+++ b/src/app/(frontend)/filmy/[slug]/_components/movie-screenings.tsx
@@ -181,8 +181,21 @@ const MovieScreenings: React.FC<MovieScreeningsProps> = ({
   movieSlug,
   movieDuration,
 }) => {
-  const { cityId, voivodeship, locationLabel, isHydrated, setCityId } =
+  const { cityId, voivodeship, locationLabel, isHydrated, setCityId, cities } =
     usePreferredCity();
+
+  // Resolve voivodeship from the canonical cities list (the same source
+  // the city select is built from) keyed by city id, rather than the
+  // screening payload's city.voivodeship - that field is not guaranteed
+  // to be populated on the per-movie screenings endpoint, which would
+  // wrongly empty the list for a voivodeship that does have showtimes.
+  const voivodeshipByCityId = useMemo(() => {
+    const map = new Map<number, string | null>();
+    for (const city of cities) {
+      map.set(city.id, city.voivodeship);
+    }
+    return map;
+  }, [cities]);
 
   // The page is statically cached with the nationwide list, so the
   // preferred-location filter is applied here after hydration. A city
@@ -194,8 +207,10 @@ const MovieScreenings: React.FC<MovieScreeningsProps> = ({
     if (cityId !== null) {
       return screenings.filter((s) => s.cinema.city.id === cityId);
     }
-    return screenings.filter((s) => s.cinema.city.voivodeship === voivodeship);
-  }, [screenings, cityId, voivodeship, isHydrated]);
+    return screenings.filter(
+      (s) => voivodeshipByCityId.get(s.cinema.city.id) === voivodeship
+    );
+  }, [screenings, cityId, voivodeship, isHydrated, voivodeshipByCityId]);
 
   const cityEmpty = screenings.length > 0 && visibleScreenings.length === 0;
 
@@ -269,7 +284,7 @@ const MovieScreenings: React.FC<MovieScreeningsProps> = ({
   if (cityEmpty) {
     return (
       <div className="flex flex-col">
-        <div className="flex justify-end pb-5 border-b border-white/10">
+        <div className="flex justify-end">
           <CityField />
         </div>
         <div className="flex flex-col items-center text-center gap-6 py-10 md:py-14">


### PR DESCRIPTION
## Problem

With a voivodeship selected, the homepage listed a film's screenings (e.g. Mazowieckie) while the film detail page showed an empty state ("Brak seansów tego filmu w województwie...").

The homepage filters by voivodeship **server-side** (`?voivodeship=`), so the API's internal city to voivodeship mapping is always used. The film detail page is statically cached with the nationwide list and filters **client-side**, comparing against `screening.cinema.city.voivodeship`. That field is not guaranteed to be populated on the per-movie screenings endpoint, so a voivodeship that does have showtimes could wrongly render the empty state.

## Fix

- Resolve the voivodeship from the canonical `cities` list in context (the same source the city select is built from), keyed by `city.id`, instead of trusting the screening payload. This keeps the film page consistent with both the city select and the homepage regardless of the per-movie response shape.
- Remove the divider line above the city select in the empty state.

## Verification

Verified with the running app:
- Mazowieckie selected: screenings render, no empty state.
- A voivodeship with no showtimes for the film: correct empty state, and the filter row's `border-bottom` is now `0px`.
- `tsc --noEmit` passes.