### PR TITLE
feat: directors pages, movie director links, listing-copy polish

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,6 +1,11 @@
 import type { NextConfig } from "next";
 import { withPayload } from "@payloadcms/next/withPayload";
 
+const PRODUCTION_URL = "https://klaps.space";
+// Mirrors the guard in robots.ts: only the production host gets the policy.
+const isProduction =
+  (process.env.NEXT_PUBLIC_SITE_URL || PRODUCTION_URL) === PRODUCTION_URL;
+
 const nextConfig: NextConfig = {
   output: "standalone",
   reactCompiler: true,
@@ -12,6 +17,24 @@ const nextConfig: NextConfig = {
         source: "/filmy",
         destination: "/seanse",
         permanent: true,
+      },
+    ];
+  },
+  async headers() {
+    // HSTS only on production. Preview/staging deployments are left off the
+    // policy so a non-HTTPS host can never get pinned in a browser. The
+    // `preload` directive opts the domain into the browser HSTS preload list
+    // (submit separately at hstspreload.org); it covers every subdomain.
+    if (!isProduction) return [];
+    return [
+      {
+        source: "/:path*",
+        headers: [
+          {
+            key: "Strict-Transport-Security",
+            value: "max-age=63072000; includeSubDomains; preload",
+          },
+        ],
       },
     ];
   },

--- a/src/app/(frontend)/(home)/_components/cinemas/index.tsx
+++ b/src/app/(frontend)/(home)/_components/cinemas/index.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import Link from "next/link";
+import { ArrowRight } from "lucide-react";
 import { getCinemas } from "@/lib/cinemas";
 
 const TOP_CITIES_LIMIT = 8;
@@ -91,27 +92,23 @@ const Cinemas = async () => {
       <div className="px-6 md:px-12 lg:px-16 pb-12 md:pb-16 flex flex-col sm:flex-row items-center justify-center gap-3 sm:gap-4">
         <Link
           href="/mapa-kin"
-          className="group inline-flex items-center gap-4 text-xs md:text-sm uppercase tracking-[0.28em] text-black bg-white hover:bg-white/90 px-8 md:px-10 py-4 md:py-5 transition-colors"
+          className="group inline-flex w-full sm:w-auto items-center justify-center gap-4 text-xs md:text-sm uppercase tracking-[0.28em] text-black bg-white hover:bg-white/90 px-8 md:px-10 py-4 md:py-5 transition-colors"
         >
           Otwórz mapę
-          <span
+          <ArrowRight
             aria-hidden="true"
-            className="transition-transform group-hover:translate-x-1"
-          >
-            →
-          </span>
+            className="size-4 shrink-0 transition-transform group-hover:translate-x-1"
+          />
         </Link>
         <Link
           href="/kina"
-          className="group inline-flex items-center gap-4 text-xs md:text-sm uppercase tracking-[0.28em] text-white border border-white/25 hover:border-white hover:bg-white/[0.04] px-8 md:px-10 py-4 md:py-5 transition-colors"
+          className="group inline-flex w-full sm:w-auto items-center justify-center gap-4 text-xs md:text-sm uppercase tracking-[0.28em] text-white border border-white/25 hover:border-white hover:bg-white/[0.04] px-8 md:px-10 py-4 md:py-5 transition-colors"
         >
           Wszystkie kina
-          <span
+          <ArrowRight
             aria-hidden="true"
-            className="transition-transform group-hover:translate-x-1"
-          >
-            →
-          </span>
+            className="size-4 shrink-0 transition-transform group-hover:translate-x-1"
+          />
         </Link>
       </div>
     </section>

--- a/src/app/(frontend)/(home)/_components/footer/index.tsx
+++ b/src/app/(frontend)/(home)/_components/footer/index.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import Image from "next/image";
 import Link from "next/link";
+import { ArrowUpRight } from "lucide-react";
 import WilhelmEgg from "./wilhelm-egg";
 
 const NAV_COLUMNS = [
@@ -11,6 +12,7 @@ const NAV_COLUMNS = [
       { label: "Kina", href: "/kina" },
       { label: "Miasta", href: "/miasta" },
       { label: "Gatunki", href: "/gatunki" },
+      { label: "Reżyserzy", href: "/rezyserzy" },
       { label: "Mapa kin", href: "/mapa-kin" },
     ],
   },
@@ -72,17 +74,15 @@ const Footer: React.FC = () => {
             href="https://github.com/klaps-hq"
             target="_blank"
             rel="noreferrer noopener nofollow"
-            className="group inline-flex items-baseline gap-2 hover:text-white transition-colors"
+            className="group inline-flex items-center gap-2 hover:text-white transition-colors"
           >
             <span className="underline underline-offset-4 decoration-white/25 group-hover:decoration-white transition-colors">
               github.com/klaps-hq
             </span>
-            <span
+            <ArrowUpRight
               aria-hidden="true"
-              className="transition-transform group-hover:translate-x-0.5 group-hover:-translate-y-0.5"
-            >
-              ↗
-            </span>
+              className="size-3.5 shrink-0 transition-transform group-hover:translate-x-0.5 group-hover:-translate-y-0.5"
+            />
           </a>
         </div>
       </div>
@@ -94,13 +94,13 @@ const Footer: React.FC = () => {
           aria-label="Klaps, strona główna"
           className="block"
         >
-          <h2 className="text-[24vw] leading-[0.78] font-bold uppercase text-white -tracking-[0.04em] whitespace-nowrap">
+          <h2 className="text-[20vw] md:text-[24vw] leading-[0.78] font-bold uppercase text-white -tracking-[0.04em] whitespace-nowrap">
             Klaps
           </h2>
         </Link>
       </div>
 
-      <div className="flex items-center gap-2 px-6 md:px-12 lg:px-16 pb-6 text-[8px] md:text-[9px] uppercase tracking-[0.2em] text-white/40">
+      <div className="flex flex-col sm:flex-row items-center gap-2 px-6 md:px-12 lg:px-16 pt-8 md:pt-4 pb-6 text-center sm:text-left text-[8px] md:text-[9px] uppercase tracking-[0.2em] text-white/40">
         <a
           href="https://www.themoviedb.org/"
           target="_blank"

--- a/src/app/(frontend)/(home)/_components/footer/wilhelm-egg.tsx
+++ b/src/app/(frontend)/(home)/_components/footer/wilhelm-egg.tsx
@@ -28,7 +28,7 @@ const WilhelmEgg: React.FC = () => {
     >
       <svg
         viewBox="0 0 28 20"
-        className="w-[16vw] h-auto text-white block"
+        className="w-[13vw] md:w-[16vw] h-auto text-white block"
         fill="currentColor"
         aria-hidden="true"
       >

--- a/src/app/(frontend)/(home)/_components/genres/index.tsx
+++ b/src/app/(frontend)/(home)/_components/genres/index.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import Link from "next/link";
+import { ArrowRight } from "lucide-react";
 import { getGenres } from "@/lib/genres";
 
 const FEATURED_COUNT = 10;
@@ -50,12 +51,10 @@ const Genres = async () => {
           className="group inline-flex items-center gap-4 text-xs md:text-sm uppercase tracking-[0.28em] text-white border border-white/25 hover:border-white hover:bg-white/[0.04] px-8 md:px-10 py-4 md:py-5 transition-colors"
         >
           Wszystkie gatunki
-          <span
+          <ArrowRight
             aria-hidden="true"
-            className="transition-transform group-hover:translate-x-1"
-          >
-            →
-          </span>
+            className="size-4 shrink-0 transition-transform group-hover:translate-x-1"
+          />
         </Link>
       </div>
     </section>

--- a/src/app/(frontend)/(home)/_components/hero/hero-parallax.tsx
+++ b/src/app/(frontend)/(home)/_components/hero/hero-parallax.tsx
@@ -6,12 +6,16 @@ import { motion, useScroll, useTransform } from "framer-motion";
 
 interface HeroParallaxProps {
   backdropSrc: string;
+  // Portrait poster shown on mobile, where the wide backdrop would crop to an
+  // unflattering center strip. Falls back to the backdrop when absent.
+  posterSrc?: string | null;
   alt: string;
   children: React.ReactNode;
 }
 
 const HeroParallax: React.FC<HeroParallaxProps> = ({
   backdropSrc,
+  posterSrc,
   alt,
   children,
 }) => {
@@ -40,15 +44,40 @@ const HeroParallax: React.FC<HeroParallaxProps> = ({
           className="absolute inset-0"
           style={{ y: imageY, scale: imageScale }}
         >
-          <Image
-            src={backdropSrc}
-            alt={alt}
-            fill
-            sizes="100vw"
-            quality={60}
-            className="object-cover"
-            priority
-          />
+          {posterSrc ? (
+            <>
+              {/* Mobile: portrait poster fills the tall viewport cleanly. */}
+              <Image
+                src={posterSrc}
+                alt={alt}
+                fill
+                sizes="100vw"
+                quality={65}
+                className="object-cover md:hidden"
+                priority
+              />
+              {/* Desktop: cinematic landscape backdrop. */}
+              <Image
+                src={backdropSrc}
+                alt={alt}
+                fill
+                sizes="100vw"
+                quality={60}
+                className="object-cover hidden md:block"
+                priority
+              />
+            </>
+          ) : (
+            <Image
+              src={backdropSrc}
+              alt={alt}
+              fill
+              sizes="100vw"
+              quality={60}
+              className="object-cover"
+              priority
+            />
+          )}
         </motion.div>
       </motion.div>
 

--- a/src/app/(frontend)/(home)/_components/hero/index.tsx
+++ b/src/app/(frontend)/(home)/_components/hero/index.tsx
@@ -8,6 +8,8 @@ import { IRandomScreening } from "@/interfaces/IScreenings";
 import { tmdbImageUrl } from "@/lib/tmdb";
 import { formatDuration, getYouTubeEmbedUrl } from "@/lib/utils";
 import TrailerModal from "@/components/common/trailer-modal";
+import MobileNav from "@/components/common/mobile-nav";
+import { NAV_LINKS } from "@/components/common/nav-links";
 import HeroParallax from "./hero-parallax";
 import { CharsReveal, TitleReveal } from "./text-reveal";
 
@@ -68,22 +70,17 @@ const HeroNav: React.FC = () => (
       </span>
     </Link>
     <div className="hidden md:flex items-center gap-6 lg:gap-8 text-sm text-white/80">
-      <Link href="/seanse" className="hover:text-white transition-colors">
-        Seanse
-      </Link>
-      <Link href="/gatunki" className="hover:text-white transition-colors">
-        Gatunki
-      </Link>
-      <Link href="/kina" className="hover:text-white transition-colors">
-        Kina
-      </Link>
-      <Link href="/miasta" className="hover:text-white transition-colors">
-        Miasta
-      </Link>
-      <Link href="/mapa-kin" className="hover:text-white transition-colors">
-        Mapa
-      </Link>
+      {NAV_LINKS.map((link) => (
+        <Link
+          key={link.href}
+          href={link.href}
+          className="hover:text-white transition-colors"
+        >
+          {link.label}
+        </Link>
+      ))}
     </div>
+    <MobileNav links={NAV_LINKS} />
   </motion.nav>
 );
 
@@ -156,6 +153,11 @@ const Hero: React.FC<HeroProps> = ({ screening }) => {
           gradient + grain so the smaller source is indistinguishable. */}
       <HeroParallax
         backdropSrc={tmdbImageUrl(screening.movie.backdropUrl ?? "", "w1280")}
+        posterSrc={
+          screening.movie.posterUrl
+            ? tmdbImageUrl(screening.movie.posterUrl, "w780")
+            : null
+        }
         alt={screening.movie.title}
       >
         <HeroNav />
@@ -230,12 +232,6 @@ const Hero: React.FC<HeroProps> = ({ screening }) => {
                   className="text-base text-white border-b border-white/50 pb-0.5 hover:border-white transition-colors"
                 >
                   {CTA_PRIMARY}
-                </Link>
-                <Link
-                  href="/seanse"
-                  className="text-base text-white/70 border-b border-white/30 pb-0.5 hover:text-white hover:border-white transition-colors"
-                >
-                  Pełny repertuar
                 </Link>
                 {embedUrl && (
                   <button

--- a/src/app/(frontend)/(home)/_components/hero/text-reveal.tsx
+++ b/src/app/(frontend)/(home)/_components/hero/text-reveal.tsx
@@ -36,25 +36,51 @@ interface TitleRevealProps {
   className?: string;
 }
 
+// Polish typography: single-letter prepositions/conjunctions must not be
+// left dangling at the end of a line. Group such a word with the one that
+// follows so they never break apart.
+const isOrphanWord = (word: string): boolean => word.replace(/\W/g, "").length === 1;
+
+// Bundle each orphan word together with the next word into one group; every
+// other word is its own group. Groups are what may wrap; words inside a group
+// stay on the same line.
+const groupOrphanWords = (words: string[]): string[][] => {
+  const groups: string[][] = [];
+  for (let i = 0; i < words.length; i += 1) {
+    if (isOrphanWord(words[i]) && i < words.length - 1) {
+      groups.push([words[i], words[i + 1]]);
+      i += 1;
+    } else {
+      groups.push([words[i]]);
+    }
+  }
+  return groups;
+};
+
 export const TitleReveal: React.FC<TitleRevealProps> = ({
   text,
   className,
 }) => {
-  const words = text.split(" ");
+  const groups = groupOrphanWords(text.split(" "));
   return (
     // h2, not h1 - the movie title is random per visit, so the stable
     // sr-only h1 in the hero carries the page's main heading instead.
     <motion.h2 className={className} variants={wordRevealContainer}>
-      {words.map((word, i) => (
-        // Top padding + matching negative margin keep the slide-up mask
-        // from clipping tall diacritics (Ś, Ć, Ó) without shifting layout.
-        <span
-          key={`${word}-${i}`}
-          className="inline-block overflow-hidden pt-[0.2em] -mt-[0.2em] pb-[0.08em] mr-[0.25em] align-bottom"
-        >
-          <motion.span className="inline-block" variants={wordRevealItem}>
-            {word}
-          </motion.span>
+      {groups.map((group, gIdx) => (
+        // whitespace-nowrap keeps a grouped orphan glued to its neighbour.
+        <span key={gIdx} className="inline-block whitespace-nowrap">
+          {group.map((word, i) => (
+            // Top padding + matching negative margin keep the slide-up mask
+            // from clipping tall diacritics (Ś, Ć, Ó) without shifting layout.
+            <span
+              key={`${word}-${i}`}
+              className="inline-block overflow-hidden pt-[0.2em] -mt-[0.2em] pb-[0.08em] mr-[0.25em] align-bottom"
+            >
+              <motion.span className="inline-block" variants={wordRevealItem}>
+                {word}
+              </motion.span>
+            </span>
+          ))}
         </span>
       ))}
     </motion.h2>

--- a/src/app/(frontend)/(home)/_components/screenings/city-field.tsx
+++ b/src/app/(frontend)/(home)/_components/screenings/city-field.tsx
@@ -173,6 +173,9 @@ const CityField: React.FC<CityFieldProps> = ({ className }) => {
           sideOffset={1}
           onOpenAutoFocus={(e) => {
             e.preventDefault();
+            // iOS zooms in and scrolls to a focused sub-16px input. Skip
+            // autofocus on touch so opening the picker stays in place.
+            if (window.matchMedia("(pointer: coarse)").matches) return;
             inputRef.current?.focus();
           }}
           className="z-50 w-[300px] bg-black border border-white/15 text-white data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 duration-150"

--- a/src/app/(frontend)/(home)/_components/screenings/filter-bar.tsx
+++ b/src/app/(frontend)/(home)/_components/screenings/filter-bar.tsx
@@ -20,10 +20,10 @@ const FilterBar: React.FC<FilterBarProps> = ({
 }) => (
   <div className="flex flex-col md:flex-row md:items-center gap-4 md:gap-6">
     <SearchField className="md:w-72 lg:w-80" />
-    <div className="flex flex-wrap items-center gap-3 md:ml-auto">
-      <DateField />
-      {!hideGenres && <GenreField genres={genres} />}
-      {!hideCity && <CityField />}
+    <div className="flex flex-col md:flex-row md:flex-wrap md:items-center gap-3 md:ml-auto">
+      <DateField className="w-full md:w-auto" />
+      {!hideGenres && <GenreField genres={genres} className="w-full md:w-auto" />}
+      {!hideCity && <CityField className="w-full md:w-auto" />}
     </div>
   </div>
 );

--- a/src/app/(frontend)/(home)/_components/screenings/genre-field.tsx
+++ b/src/app/(frontend)/(home)/_components/screenings/genre-field.tsx
@@ -69,6 +69,9 @@ const GenreField: React.FC<GenreFieldProps> = ({ genres, className }) => {
           sideOffset={1}
           onOpenAutoFocus={(e) => {
             e.preventDefault();
+            // iOS zooms in and scrolls to a focused sub-16px input. Skip
+            // autofocus on touch so opening the picker stays in place.
+            if (window.matchMedia("(pointer: coarse)").matches) return;
             inputRef.current?.focus();
           }}
           className="z-50 w-[300px] bg-black border border-white/15 text-white data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 duration-150"

--- a/src/app/(frontend)/(home)/_components/screenings/screenings-section.tsx
+++ b/src/app/(frontend)/(home)/_components/screenings/screenings-section.tsx
@@ -2,6 +2,7 @@
 
 import React from "react";
 import Link from "next/link";
+import { ArrowRight } from "lucide-react";
 import { IScreeningGroup } from "@/interfaces/IScreenings";
 import { IGenre } from "@/interfaces/IMovies";
 import {
@@ -69,12 +70,10 @@ const ScreeningsSectionInner: React.FC<ScreeningsSectionProps> = ({
               className="group inline-flex items-center gap-4 text-xs md:text-sm uppercase tracking-[0.28em] text-white border border-white/25 hover:border-white hover:bg-white/[0.04] px-8 md:px-10 py-4 md:py-5 transition-colors"
             >
               Zobacz wszystkie seanse
-              <span
+              <ArrowRight
                 aria-hidden="true"
-                className="transition-transform group-hover:translate-x-1"
-              >
-                →
-              </span>
+                className="size-4 shrink-0 transition-transform group-hover:translate-x-1"
+              />
             </Link>
           </div>
         )}

--- a/src/app/(frontend)/components/common/director-photo.tsx
+++ b/src/app/(frontend)/components/common/director-photo.tsx
@@ -1,0 +1,73 @@
+"use client";
+
+import React, { useState } from "react";
+import Image from "next/image";
+import { cn } from "@/lib/utils";
+import { resolveTmdbPhotoUrl } from "@/lib/tmdb";
+
+interface DirectorPhotoProps {
+  photoUrl: string | null;
+  name: string;
+  width: number;
+  height: number;
+  /** Responsive sizes hint - set per grid layout to avoid oversized downloads. */
+  sizes?: string;
+  className?: string;
+  /** Set for above-the-fold (LCP) photos to skip lazy loading. */
+  priority?: boolean;
+}
+
+// Up to two initials from the name, used when there is no usable photo.
+const initialsOf = (name: string): string =>
+  name
+    .split(/\s+/)
+    .filter(Boolean)
+    .slice(0, 2)
+    .map((part) => part[0]?.toUpperCase() ?? "")
+    .join("");
+
+const DirectorPhoto: React.FC<DirectorPhotoProps> = ({
+  photoUrl,
+  name,
+  width,
+  height,
+  sizes,
+  className,
+  priority = false,
+}) => {
+  const [isError, setIsError] = useState(false);
+  const src = resolveTmdbPhotoUrl(photoUrl, "w342");
+
+  if (!src || isError) {
+    return (
+      <div
+        className={cn(
+          "flex items-center justify-center bg-white/[0.05] text-white/30",
+          className
+        )}
+      >
+        <span
+          aria-hidden="true"
+          className="text-lg md:text-2xl font-medium uppercase tracking-[0.15em]"
+        >
+          {initialsOf(name)}
+        </span>
+      </div>
+    );
+  }
+
+  return (
+    <Image
+      src={src}
+      alt={`Zdjęcie: ${name}`}
+      width={width}
+      height={height}
+      sizes={sizes}
+      priority={priority}
+      className={className}
+      onError={() => setIsError(true)}
+    />
+  );
+};
+
+export default DirectorPhoto;

--- a/src/app/(frontend)/components/common/empty-state.tsx
+++ b/src/app/(frontend)/components/common/empty-state.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import Link from "next/link";
+import { ArrowRight } from "lucide-react";
 import { cn } from "@/lib/utils";
 
 interface EmptyStateCta {
@@ -28,12 +29,10 @@ const EmptyState: React.FC<EmptyStateProps> = ({
   const ctaContent = cta && (
     <>
       {cta.label}
-      <span
+      <ArrowRight
         aria-hidden="true"
-        className="transition-transform group-hover:translate-x-1"
-      >
-        →
-      </span>
+        className="size-4 shrink-0 transition-transform group-hover:translate-x-1"
+      />
     </>
   );
 

--- a/src/app/(frontend)/components/common/mobile-nav.tsx
+++ b/src/app/(frontend)/components/common/mobile-nav.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React, { useEffect, useState } from "react";
+import { createPortal } from "react-dom";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { AnimatePresence, motion } from "framer-motion";
@@ -16,7 +17,14 @@ interface MobileNavProps {
 
 const MobileNav: React.FC<MobileNavProps> = ({ links }) => {
   const [open, setOpen] = useState(false);
+  const [mounted, setMounted] = useState(false);
   const pathname = usePathname();
+
+  // Portal target (document.body) is only available after mount (client-side).
+  useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setMounted(true);
+  }, []);
 
   // Lock body scroll while the menu is open.
   useEffect(() => {
@@ -47,93 +55,97 @@ const MobileNav: React.FC<MobileNavProps> = ({ links }) => {
         Menu
       </button>
 
-      <AnimatePresence>
-        {open && (
-          <motion.div
-            role="dialog"
-            aria-modal="true"
-            aria-label="Menu nawigacji"
-            initial={{ opacity: 0 }}
-            animate={{ opacity: 1 }}
-            exit={{ opacity: 0 }}
-            transition={{ duration: 0.25 }}
-            className="fixed inset-0 z-[90] bg-black flex flex-col"
-          >
-            <div className="flex items-center justify-between px-6 py-6 border-b border-white/10">
-              <Link
-                href="/"
-                aria-label="Klaps, strona główna"
-                className="flex items-center gap-2.5 text-white"
-                onClick={() => setOpen(false)}
+      {mounted &&
+        createPortal(
+          <AnimatePresence>
+            {open && (
+              <motion.div
+                role="dialog"
+                aria-modal="true"
+                aria-label="Menu nawigacji"
+                initial={{ opacity: 0 }}
+                animate={{ opacity: 1 }}
+                exit={{ opacity: 0 }}
+                transition={{ duration: 0.25 }}
+                className="fixed inset-0 z-[90] bg-black flex flex-col"
               >
-                <svg
-                  viewBox="0 0 28 20"
-                  className="w-5 h-5"
-                  fill="currentColor"
-                  aria-hidden="true"
-                >
-                  <polygon points="0,8 28,0 28,20 0,12" />
-                </svg>
-                <span className="text-xl font-medium lowercase tracking-tight">
-                  klaps
-                </span>
-              </Link>
-              <button
-                type="button"
-                onClick={() => setOpen(false)}
-                aria-label="Zamknij menu"
-                className="text-[11px] uppercase tracking-[0.25em] text-white/60 hover:text-white transition-colors py-2"
-              >
-                Zamknij
-              </button>
-            </div>
-
-            <motion.nav
-              aria-label="Główna nawigacja"
-              className="flex-1 flex flex-col justify-center px-6"
-              initial="hidden"
-              animate="visible"
-              variants={{
-                hidden: {},
-                visible: {
-                  transition: { staggerChildren: 0.06, delayChildren: 0.1 },
-                },
-              }}
-            >
-              <ul className="flex flex-col divide-y divide-white/10">
-                {links.map((link) => (
-                  <motion.li
-                    key={link.href}
-                    variants={{
-                      hidden: { opacity: 0, y: 16 },
-                      visible: {
-                        opacity: 1,
-                        y: 0,
-                        transition: {
-                          duration: 0.5,
-                          ease: [0.22, 1, 0.36, 1],
-                        },
-                      },
-                    }}
+                <div className="flex items-center justify-between px-6 py-5 border-b border-white/10">
+                  <Link
+                    href="/"
+                    aria-label="Klaps, strona główna"
+                    className="flex items-center gap-2.5 text-white"
+                    onClick={() => setOpen(false)}
                   >
-                    <Link
-                      href={link.href}
-                      onClick={() => setOpen(false)}
-                      className={
-                        pathname === link.href
-                          ? "block py-5 text-4xl font-medium uppercase -tracking-[0.02em] leading-none text-white"
-                          : "block py-5 text-4xl font-medium uppercase -tracking-[0.02em] leading-none text-white/55 hover:text-white transition-colors"
-                      }
+                    <svg
+                      viewBox="0 0 28 20"
+                      className="w-5 h-5"
+                      fill="currentColor"
+                      aria-hidden="true"
                     >
-                      {link.label}
-                    </Link>
-                  </motion.li>
-                ))}
-              </ul>
-            </motion.nav>
-          </motion.div>
+                      <polygon points="0,8 28,0 28,20 0,12" />
+                    </svg>
+                    <span className="text-xl font-medium lowercase tracking-tight">
+                      klaps
+                    </span>
+                  </Link>
+                  <button
+                    type="button"
+                    onClick={() => setOpen(false)}
+                    aria-label="Zamknij menu"
+                    className="text-[11px] uppercase tracking-[0.25em] text-white/60 hover:text-white transition-colors py-2"
+                  >
+                    Zamknij
+                  </button>
+                </div>
+
+                <motion.nav
+                  aria-label="Główna nawigacja"
+                  className="flex-1 flex flex-col justify-center px-6"
+                  initial="hidden"
+                  animate="visible"
+                  variants={{
+                    hidden: {},
+                    visible: {
+                      transition: { staggerChildren: 0.06, delayChildren: 0.1 },
+                    },
+                  }}
+                >
+                  <ul className="flex flex-col divide-y divide-white/10">
+                    {links.map((link) => (
+                      <motion.li
+                        key={link.href}
+                        variants={{
+                          hidden: { opacity: 0, y: 16 },
+                          visible: {
+                            opacity: 1,
+                            y: 0,
+                            transition: {
+                              duration: 0.5,
+                              ease: [0.22, 1, 0.36, 1],
+                            },
+                          },
+                        }}
+                      >
+                        <Link
+                          href={link.href}
+                          onClick={() => setOpen(false)}
+                          className={
+                            pathname === link.href
+                              ? "block py-5 text-4xl font-medium uppercase -tracking-[0.02em] leading-none text-white"
+                              : "block py-5 text-4xl font-medium uppercase -tracking-[0.02em] leading-none text-white/55 hover:text-white transition-colors"
+                          }
+                        >
+                          {link.label}
+                        </Link>
+                      </motion.li>
+                    ))}
+                  </ul>
+                </motion.nav>
+              </motion.div>
+            )}
+          </AnimatePresence>,
+          document.body
         )}
-      </AnimatePresence>
     </div>
   );
 };

--- a/src/app/(frontend)/components/common/nav-links.ts
+++ b/src/app/(frontend)/components/common/nav-links.ts
@@ -1,0 +1,15 @@
+export interface NavLink {
+  href: string;
+  label: string;
+}
+
+// Shared primary navigation, used by the site header (desktop + mobile) and
+// the homepage hero nav so the link set never drifts between them.
+export const NAV_LINKS: NavLink[] = [
+  { href: "/seanse", label: "Seanse" },
+  { href: "/gatunki", label: "Gatunki" },
+  { href: "/rezyserzy", label: "Reżyserzy" },
+  { href: "/kina", label: "Kina" },
+  { href: "/miasta", label: "Miasta" },
+  { href: "/mapa-kin", label: "Mapa" },
+];

--- a/src/app/(frontend)/components/common/paginated-nav.tsx
+++ b/src/app/(frontend)/components/common/paginated-nav.tsx
@@ -58,7 +58,7 @@ const PaginatedNav: React.FC<PaginatedNavProps> = ({
 
   return (
     <Pagination>
-      <PaginationContent className="gap-1">
+      <PaginationContent className="gap-4 md:gap-6">
         <PaginationItem>
           <PaginationPrevious
             href={hasPrevious ? buildHref(currentPage - 1) : undefined}

--- a/src/app/(frontend)/components/common/site-header.tsx
+++ b/src/app/(frontend)/components/common/site-header.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import Link from "next/link";
 import {
   motion,
@@ -13,14 +13,7 @@ import {
 } from "framer-motion";
 import { cn } from "@/lib/utils";
 import MobileNav from "./mobile-nav";
-
-const NAV_LINKS = [
-  { href: "/seanse", label: "Seanse" },
-  { href: "/gatunki", label: "Gatunki" },
-  { href: "/kina", label: "Kina" },
-  { href: "/miasta", label: "Miasta" },
-  { href: "/mapa-kin", label: "Mapa" },
-];
+import { NAV_LINKS } from "./nav-links";
 
 // Scroll distance (px) over which the header morphs from a transparent
 // full-width bar into the floating glass capsule.
@@ -53,6 +46,18 @@ const SiteHeader: React.FC<SiteHeaderProps> = ({ overlay = false }) => {
   const reducedMotion = useReducedMotion();
   const { scrollY } = useScroll();
   const progress = useMorphProgress(scrollY);
+
+  // Below md the header stays full-width: the floating-capsule inset (side
+  // margins + radius) would look cramped, so it morphs to a plain solid bar.
+  const [isMobile, setIsMobile] = useState(false);
+  useEffect(() => {
+    const mq = window.matchMedia("(max-width: 767px)");
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setIsMobile(mq.matches);
+    const onChange = (e: MediaQueryListEvent) => setIsMobile(e.matches);
+    mq.addEventListener("change", onChange);
+    return () => mq.removeEventListener("change", onChange);
+  }, []);
 
   // Overlay visibility: reveal on scroll-up past the threshold, hide on
   // scroll-down so it never fights the listing's own sticky filter bar.
@@ -109,19 +114,22 @@ const SiteHeader: React.FC<SiteHeaderProps> = ({ overlay = false }) => {
     >
       <motion.div
         style={{
-          y,
-          marginLeft: marginX,
-          marginRight: marginX,
-          borderRadius,
+          y: isMobile ? 0 : y,
+          marginLeft: isMobile ? 0 : marginX,
+          marginRight: isMobile ? 0 : marginX,
+          borderRadius: isMobile ? 0 : borderRadius,
           backgroundColor,
           borderColor,
           backdropFilter,
           WebkitBackdropFilter: backdropFilter,
           boxShadow,
         }}
-        className="flex items-center justify-between gap-8 border px-6 md:px-10 lg:px-12 py-5"
+        className="flex items-center justify-between gap-8 border-x-0 border-b md:border px-6 md:px-10 lg:px-12 py-5"
       >
-        <motion.div style={{ scale: logoScale }} className="origin-left shrink-0">
+        <motion.div
+          style={{ scale: isMobile ? 1 : logoScale }}
+          className="origin-left shrink-0"
+        >
           <Link
             href="/"
             aria-label="Klaps, strona główna"

--- a/src/app/(frontend)/components/ui/map.tsx
+++ b/src/app/(frontend)/components/ui/map.tsx
@@ -1399,18 +1399,23 @@ function MapClusterLayer<
   useEffect(() => {
     if (!isLoaded || !map) return;
 
-    // Cluster click handler - zoom into cluster
-    const handleClusterClick = async (
-      e: MapLibreGL.MapMouseEvent & {
-        features?: MapLibreGL.MapGeoJSONFeature[];
-      }
-    ) => {
-      const features = map.queryRenderedFeatures(e.point, {
-        layers: [clusterLayerId],
-      });
-      if (!features.length) return;
+    // Touch targets are tiny (a few px), so a precise tap on the rendered
+    // circle is unreliable on phones. Query a padded box around the tap
+    // point instead; the padding is larger for coarse pointers (fingers).
+    const isCoarsePointer =
+      typeof window !== "undefined" &&
+      window.matchMedia("(pointer: coarse)").matches;
+    const hitPad = isCoarsePointer ? 16 : 5;
+    const paddedBox = (
+      point: MapLibreGL.Point
+    ): [MapLibreGL.PointLike, MapLibreGL.PointLike] => [
+      [point.x - hitPad, point.y - hitPad],
+      [point.x + hitPad, point.y + hitPad],
+    ];
 
-      const feature = features[0];
+    const expandCluster = async (
+      feature: MapLibreGL.MapGeoJSONFeature
+    ): Promise<void> => {
       const clusterId = feature.properties?.cluster_id as number;
       const pointCount = feature.properties?.point_count as number;
       const coordinates = (feature.geometry as GeoJSON.Point).coordinates as [
@@ -1424,35 +1429,50 @@ function MapClusterLayer<
         // Default behavior: zoom to cluster expansion zoom
         const source = map.getSource(sourceId) as MapLibreGL.GeoJSONSource;
         const zoom = await source.getClusterExpansionZoom(clusterId);
-        map.easeTo({
-          center: coordinates,
-          zoom,
-        });
+        map.easeTo({ center: coordinates, zoom });
       }
     };
 
-    // Unclustered point click handler
-    const handlePointClick = (
-      e: MapLibreGL.MapMouseEvent & {
-        features?: MapLibreGL.MapGeoJSONFeature[];
-      }
-    ) => {
-      if (!onPointClick || !e.features?.length) return;
+    const selectPoint = (
+      feature: MapLibreGL.MapGeoJSONFeature,
+      lng: number
+    ): void => {
+      if (!onPointClick) return;
 
-      const feature = e.features[0];
       const coordinates = (
         feature.geometry as GeoJSON.Point
       ).coordinates.slice() as [number, number];
 
       // Handle world copies
-      while (Math.abs(e.lngLat.lng - coordinates[0]) > 180) {
-        coordinates[0] += e.lngLat.lng > coordinates[0] ? 360 : -360;
+      while (Math.abs(lng - coordinates[0]) > 180) {
+        coordinates[0] += lng > coordinates[0] ? 360 : -360;
       }
 
       onPointClick(
         feature as unknown as GeoJSON.Feature<GeoJSON.Point, P>,
         coordinates
       );
+    };
+
+    // Single map-level handler with tap tolerance. Clusters win over points
+    // when both fall inside the box, matching the visual stacking order.
+    const handleMapClick = (e: MapLibreGL.MapMouseEvent) => {
+      const box = paddedBox(e.point);
+
+      const clusters = map.queryRenderedFeatures(box, {
+        layers: [clusterLayerId],
+      });
+      if (clusters.length) {
+        void expandCluster(clusters[0]);
+        return;
+      }
+
+      const points = map.queryRenderedFeatures(box, {
+        layers: [unclusteredLayerId],
+      });
+      if (points.length) {
+        selectPoint(points[0], e.lngLat.lng);
+      }
     };
 
     // Cursor style handlers
@@ -1471,16 +1491,14 @@ function MapClusterLayer<
       map.getCanvas().style.cursor = "";
     };
 
-    map.on("click", clusterLayerId, handleClusterClick);
-    map.on("click", unclusteredLayerId, handlePointClick);
+    map.on("click", handleMapClick);
     map.on("mouseenter", clusterLayerId, handleMouseEnterCluster);
     map.on("mouseleave", clusterLayerId, handleMouseLeaveCluster);
     map.on("mouseenter", unclusteredLayerId, handleMouseEnterPoint);
     map.on("mouseleave", unclusteredLayerId, handleMouseLeavePoint);
 
     return () => {
-      map.off("click", clusterLayerId, handleClusterClick);
-      map.off("click", unclusteredLayerId, handlePointClick);
+      map.off("click", handleMapClick);
       map.off("mouseenter", clusterLayerId, handleMouseEnterCluster);
       map.off("mouseleave", clusterLayerId, handleMouseLeaveCluster);
       map.off("mouseenter", unclusteredLayerId, handleMouseEnterPoint);

--- a/src/app/(frontend)/components/ui/pagination.tsx
+++ b/src/app/(frontend)/components/ui/pagination.tsx
@@ -20,7 +20,10 @@ function PaginationContent({
   return (
     <ul
       data-slot="pagination-content"
-      className={cn("flex flex-row items-center gap-5 md:gap-6", className)}
+      className={cn(
+        "flex flex-row flex-wrap items-center justify-center gap-5 md:gap-6",
+        className,
+      )}
       {...props}
     />
   );
@@ -44,7 +47,7 @@ function PaginationLink({
       data-slot="pagination-link"
       data-active={isActive}
       className={cn(
-        "inline-flex items-baseline justify-center text-sm md:text-base tabular-nums tracking-tight transition-colors duration-200 cursor-pointer pb-1 border-b",
+        "inline-flex items-baseline justify-center text-lg md:text-xl tabular-nums tracking-tight transition-colors duration-200 cursor-pointer pb-1 border-b",
         isActive
           ? "text-white border-white"
           : "text-white/40 border-transparent hover:text-white hover:border-white/40",
@@ -69,7 +72,7 @@ function PaginationPrevious({
       )}
       {...props}
     >
-      <ChevronLeftIcon className="size-5" />
+      <ChevronLeftIcon className="size-6" />
     </a>
   );
 }
@@ -88,7 +91,7 @@ function PaginationNext({
       )}
       {...props}
     >
-      <ChevronRightIcon className="size-5" />
+      <ChevronRightIcon className="size-6" />
     </a>
   );
 }
@@ -101,7 +104,7 @@ function PaginationEllipsis({
     <span
       data-slot="pagination-ellipsis"
       className={cn(
-        "inline-flex items-baseline justify-center text-white/25 text-sm",
+        "inline-flex items-baseline justify-center text-white/25 text-lg md:text-xl",
         className,
       )}
       {...props}

--- a/src/app/(frontend)/faq/page.tsx
+++ b/src/app/(frontend)/faq/page.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import Link from "next/link";
+import { ArrowRight } from "lucide-react";
 import Breadcrumbs from "@/components/ui/breadcrumbs";
 import PageHeading from "@/components/ui/page-heading";
 import SiteHeader from "@/components/common/site-header";
@@ -77,12 +78,10 @@ const FaqPage = () => {
           className="group mt-10 md:mt-12 inline-flex items-center gap-4 text-xs md:text-sm uppercase tracking-[0.28em] text-white border border-white/25 hover:border-white hover:bg-white/[0.04] px-8 md:px-10 py-4 md:py-5 transition-colors"
         >
           Kontakt
-          <span
+          <ArrowRight
             aria-hidden="true"
-            className="transition-transform group-hover:translate-x-1"
-          >
-            →
-          </span>
+            className="size-4 shrink-0 transition-transform group-hover:translate-x-1"
+          />
         </Link>
       </section>
 

--- a/src/app/(frontend)/filmy/[slug]/_components/movie-about.tsx
+++ b/src/app/(frontend)/filmy/[slug]/_components/movie-about.tsx
@@ -1,13 +1,37 @@
 import React from "react";
 import Link from "next/link";
-import { IMovie } from "@/interfaces/IMovies";
+import { IMovie, IMoviePerson } from "@/interfaces/IMovies";
 import { cn, formatDatePL, formatDuration, formatNames } from "@/lib/utils";
 import { pluralPl } from "@/lib/seo";
 
 interface CreditItem {
   label: string;
-  value: string;
+  value: React.ReactNode;
 }
+
+// Directors carry a slug, so render each as a link to its page; other people
+// (scriptwriters, cast) stay plain text. Falls back to a plain name when a
+// director has no slug yet.
+const renderPeopleLinks = (
+  people?: IMoviePerson[] | null
+): React.ReactNode => {
+  if (!people || people.length === 0) return null;
+  return people.map((person, index) => (
+    <React.Fragment key={person.id ?? person.name}>
+      {index > 0 && ", "}
+      {person.slug ? (
+        <Link
+          href={`/rezyserzy/${person.slug}`}
+          className="border-b border-white/25 hover:border-white pb-0.5 transition-colors"
+        >
+          {person.name}
+        </Link>
+      ) : (
+        person.name
+      )}
+    </React.Fragment>
+  ));
+};
 
 interface AboutCellProps {
   label: string;
@@ -36,16 +60,16 @@ interface MovieAboutProps {
 }
 
 const MovieAbout: React.FC<MovieAboutProps> = ({ movie }) => {
-  const directors = formatNames(movie.directors);
+  const directorNodes = renderPeopleLinks(movie.directors);
   const scriptwriters = formatNames(movie.scriptwriters ?? movie.screenwriters);
   const actors = formatNames(movie.actors);
   const countries = formatNames(movie.countries ?? movie.countryOfOrigin);
   const premierePL = formatDatePL(movie.polishPremiereDate);
 
   const credits: CreditItem[] = [
-    { label: "Reżyseria", value: directors ?? "" },
-    { label: "Scenariusz", value: scriptwriters ?? "" },
-  ].filter((i) => i.value.trim() !== "");
+    ...(directorNodes ? [{ label: "Reżyseria", value: directorNodes }] : []),
+    ...(scriptwriters ? [{ label: "Scenariusz", value: scriptwriters }] : []),
+  ];
 
   const meta: CreditItem[] = [
     { label: "Rok produkcji", value: movie.productionYear?.toString() ?? "" },

--- a/src/app/(frontend)/filmy/[slug]/_components/movie-hero.tsx
+++ b/src/app/(frontend)/filmy/[slug]/_components/movie-hero.tsx
@@ -2,6 +2,7 @@
 
 import React, { useRef, useState } from "react";
 import Image from "next/image";
+import Link from "next/link";
 import { motion, useScroll, useTransform } from "framer-motion";
 import { Play } from "lucide-react";
 import { IMovie } from "@/interfaces/IMovies";
@@ -134,6 +135,36 @@ const MovieHero: React.FC<MovieHeroProps> = ({ movie }) => {
                 className="text-base md:text-xl text-white/55 italic font-light"
               >
                 {movie.titleOriginal}
+              </motion.span>
+            )}
+            {movie.directors && movie.directors.length > 0 && (
+              <motion.span
+                variants={{
+                  hidden: { opacity: 0, y: 16 },
+                  visible: {
+                    opacity: 1,
+                    y: 0,
+                    transition: { duration: 0.5, ease: [0.22, 1, 0.36, 1] },
+                  },
+                }}
+                className="text-xs md:text-sm uppercase tracking-[0.25em] text-white/65"
+              >
+                <span className="text-white/45">Reżyseria</span>{" "}
+                {movie.directors.map((person, index) => (
+                  <React.Fragment key={person.id ?? person.name}>
+                    {index > 0 && ", "}
+                    {person.slug ? (
+                      <Link
+                        href={`/rezyserzy/${person.slug}`}
+                        className="border-b border-white/30 hover:border-white transition-colors"
+                      >
+                        {person.name}
+                      </Link>
+                    ) : (
+                      person.name
+                    )}
+                  </React.Fragment>
+                ))}
               </motion.span>
             )}
             {movie.description && (

--- a/src/app/(frontend)/filmy/[slug]/_components/movie-screenings.tsx
+++ b/src/app/(frontend)/filmy/[slug]/_components/movie-screenings.tsx
@@ -2,6 +2,7 @@
 
 import React, { useEffect, useMemo, useState } from "react";
 import Link from "next/link";
+import { ArrowRight } from "lucide-react";
 import { IScreening } from "@/interfaces/IScreenings";
 import CityField from "@/app/(home)/_components/screenings/city-field";
 import AddToCalendarButton from "@/components/common/add-to-calendar-button";
@@ -248,31 +249,27 @@ const MovieScreenings: React.FC<MovieScreeningsProps> = ({
         <div className="flex flex-wrap items-center justify-center gap-x-8 gap-y-3">
           <Link
             href="/seanse"
-            className="group inline-flex items-baseline gap-2.5 text-[11px] md:text-xs uppercase tracking-[0.25em] text-white"
+            className="group inline-flex items-center gap-2.5 text-[11px] md:text-xs uppercase tracking-[0.25em] text-white"
           >
             <span className="underline underline-offset-4 decoration-white/30 group-hover:decoration-white transition-colors">
               Pełny repertuar
             </span>
-            <span
+            <ArrowRight
               aria-hidden="true"
-              className="transition-transform group-hover:translate-x-1"
-            >
-              →
-            </span>
+              className="size-3.5 shrink-0 transition-transform group-hover:translate-x-1"
+            />
           </Link>
           <Link
             href="/kina"
-            className="group inline-flex items-baseline gap-2.5 text-[11px] md:text-xs uppercase tracking-[0.25em] text-white/70 hover:text-white transition-colors"
+            className="group inline-flex items-center gap-2.5 text-[11px] md:text-xs uppercase tracking-[0.25em] text-white/70 hover:text-white transition-colors"
           >
             <span className="underline underline-offset-4 decoration-white/20 group-hover:decoration-white transition-colors">
               Kina studyjne
             </span>
-            <span
+            <ArrowRight
               aria-hidden="true"
-              className="transition-transform group-hover:translate-x-1"
-            >
-              →
-            </span>
+              className="size-3.5 shrink-0 transition-transform group-hover:translate-x-1"
+            />
           </Link>
         </div>
       </div>
@@ -318,27 +315,29 @@ const MovieScreenings: React.FC<MovieScreeningsProps> = ({
 
   return (
     <div className="flex flex-col">
-      <div className="flex flex-wrap items-center gap-x-6 gap-y-3 pb-5 border-b border-white/10">
-        {availableDates.map((date) => {
-          const active = activeDate === date;
-          return (
-            <button
-              key={date}
-              type="button"
-              onClick={() => setSelectedDate(date)}
-              className={cn(
-                "shrink-0 pb-1 text-[11px] uppercase tracking-wider border-b transition-colors whitespace-nowrap",
-                active
-                  ? "text-white border-white"
-                  : "text-white/55 border-transparent hover:text-white hover:border-white/40"
-              )}
-            >
-              {formatFullDateLabel(date)}
-            </button>
-          );
-        })}
-        <div className="ml-auto">
-          <CityField />
+      <div className="flex flex-col md:flex-row md:flex-wrap md:items-center gap-4 md:gap-x-6 md:gap-y-3 pb-5 border-b border-white/10">
+        <div className="flex flex-wrap items-center gap-x-6 gap-y-3">
+          {availableDates.map((date) => {
+            const active = activeDate === date;
+            return (
+              <button
+                key={date}
+                type="button"
+                onClick={() => setSelectedDate(date)}
+                className={cn(
+                  "shrink-0 pb-1 text-[11px] uppercase tracking-wider border-b transition-colors whitespace-nowrap",
+                  active
+                    ? "text-white border-white"
+                    : "text-white/55 border-transparent hover:text-white hover:border-white/40"
+                )}
+              >
+                {formatFullDateLabel(date)}
+              </button>
+            );
+          })}
+        </div>
+        <div className="md:ml-auto">
+          <CityField className="w-full md:w-auto" />
         </div>
       </div>
 

--- a/src/app/(frontend)/gatunki/[slug]/page.tsx
+++ b/src/app/(frontend)/gatunki/[slug]/page.tsx
@@ -1,6 +1,7 @@
 import React, { Suspense } from "react";
 import Link from "next/link";
 import { Metadata } from "next";
+import { ArrowRight } from "lucide-react";
 import { getGenrePageData, getGenres } from "@/lib/genres";
 import { getMovies } from "@/lib/movies";
 import { getScreenings } from "@/lib/screenings";
@@ -142,15 +143,13 @@ const GenrePage = async ({ params }: GenrePageProps) => {
             </h2>
             <Link
               href="/gatunki"
-              className="group inline-flex items-baseline gap-2 text-[10px] md:text-xs uppercase tracking-[0.28em] text-white/55 hover:text-white transition-colors border-b border-transparent hover:border-white/40 pb-0.5"
+              className="group inline-flex items-center gap-2 text-[10px] md:text-xs uppercase tracking-[0.28em] text-white/55 hover:text-white transition-colors border-b border-transparent hover:border-white/40 pb-0.5"
             >
               Wszystkie gatunki
-              <span
+              <ArrowRight
                 aria-hidden="true"
-                className="transition-transform group-hover:translate-x-1"
-              >
-                →
-              </span>
+                className="size-3.5 shrink-0 transition-transform group-hover:translate-x-1"
+              />
             </Link>
           </div>
           <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 border-t border-l border-white/10">

--- a/src/app/(frontend)/gatunki/[slug]/page.tsx
+++ b/src/app/(frontend)/gatunki/[slug]/page.tsx
@@ -7,6 +7,7 @@ import { getMovies } from "@/lib/movies";
 import { getScreenings } from "@/lib/screenings";
 import { SITE_URL } from "@/lib/site-config";
 import { BASE_OPEN_GRAPH, NOINDEX_FOLLOW, pluralPl } from "@/lib/seo";
+import { genreFallbackIntro } from "@/lib/listing-copy";
 import Breadcrumbs from "@/components/ui/breadcrumbs";
 import PageHeading from "@/components/ui/page-heading";
 import SiteHeader from "@/components/common/site-header";
@@ -118,9 +119,7 @@ const GenrePage = async ({ params }: GenrePageProps) => {
           </p>
         ) : (
           <p className="mt-8 md:mt-10 max-w-[64ch] text-base md:text-lg text-white/55 leading-relaxed">
-            Filmy z&nbsp;gatunku {genreNameLower} pokazywane aktualnie
-            w&nbsp;polskich kinach studyjnych. Filtruj po mieście, dacie
-            lub frazie poniżej.
+            {genreFallbackIntro(genreNameLower, screenings)}
           </p>
         )}
       </header>

--- a/src/app/(frontend)/interfaces/IDirectors.ts
+++ b/src/app/(frontend)/interfaces/IDirectors.ts
@@ -1,0 +1,19 @@
+export type DirectorRole = "director" | "actor" | "screenwriter";
+
+export interface IDirector {
+  id: number;
+  /** Canonical, stable slug. */
+  slug: string;
+  name: string;
+  /** TMDB person id. */
+  sourceId: number;
+  /** Currently always "director". */
+  role: DirectorRole;
+  bio: string | null;
+  photoUrl: string | null;
+  /** Screenings dated today or later. */
+  upcomingScreeningsCount: number;
+  moviesCount: number;
+  /** ISO 8601 UTC. */
+  updatedAt: string | null;
+}

--- a/src/app/(frontend)/interfaces/IMovies.ts
+++ b/src/app/(frontend)/interfaces/IMovies.ts
@@ -9,6 +9,8 @@ export interface IGenre {
 export interface IMoviePerson {
   id?: number;
   sourceId?: number;
+  /** Director slug for linking to /rezyserzy/[slug]; absent for cast/crew. */
+  slug?: string;
   name: string;
   url?: string;
 }

--- a/src/app/(frontend)/interfaces/ISitemap.ts
+++ b/src/app/(frontend)/interfaces/ISitemap.ts
@@ -10,4 +10,6 @@ export interface ISitemapResponse {
   /** Only cities with at least one cinema. */
   cities: ISitemapEntry[];
   genres: ISitemapEntry[];
+  /** Only directors above the indexing threshold (>= 3 upcoming screenings). */
+  directors?: ISitemapEntry[];
 }

--- a/src/app/(frontend)/kina/[slug]/page.tsx
+++ b/src/app/(frontend)/kina/[slug]/page.tsx
@@ -1,6 +1,7 @@
 import React, { Suspense } from "react";
 import Link from "next/link";
 import { Metadata } from "next";
+import { ArrowUpRight } from "lucide-react";
 import { getCinemaPageData, getCinemaBySlug, getCinemas } from "@/lib/cinemas";
 import { getGenres } from "@/lib/genres";
 import { getScreenings } from "@/lib/screenings";
@@ -161,9 +162,13 @@ const CinemaPageContent = async ({ slug }: { slug: string }) => {
                       href={cinema.sourceUrl}
                       target="_blank"
                       rel="noreferrer noopener nofollow"
-                      className="text-white/70 hover:text-white transition-colors border-b border-transparent hover:border-white/40 pb-0.5"
+                      className="group inline-flex items-center gap-1 text-white/70 hover:text-white transition-colors border-b border-transparent hover:border-white/40 pb-0.5"
                     >
-                      Strona kina ↗
+                      Strona kina
+                      <ArrowUpRight
+                        aria-hidden="true"
+                        className="size-3.5 shrink-0 transition-transform group-hover:translate-x-0.5 group-hover:-translate-y-0.5"
+                      />
                     </Link>
                   </>
                 )}

--- a/src/app/(frontend)/kontakt/page.tsx
+++ b/src/app/(frontend)/kontakt/page.tsx
@@ -6,6 +6,7 @@ import {
   FaThreads,
   FaXTwitter,
 } from "react-icons/fa6";
+import { ArrowRight, ArrowUpRight } from "lucide-react";
 import Breadcrumbs from "@/components/ui/breadcrumbs";
 import PageHeading from "@/components/ui/page-heading";
 import SiteHeader from "@/components/common/site-header";
@@ -78,17 +79,15 @@ const ContactPage = () => {
           <div className="lg:col-span-8">
             <a
               href={`mailto:${CONTACT_EMAIL}`}
-              className="group inline-flex items-baseline gap-4 md:gap-6"
+              className="group inline-flex items-center gap-4 md:gap-6"
             >
               <span className="text-2xl md:text-4xl lg:text-5xl font-medium text-white -tracking-[0.02em] break-all">
                 {CONTACT_EMAIL}
               </span>
-              <span
+              <ArrowUpRight
                 aria-hidden="true"
-                className="shrink-0 text-2xl md:text-3xl text-white/40 group-hover:text-white transition-transform group-hover:translate-x-1 group-hover:-translate-y-1"
-              >
-                ↗
-              </span>
+                className="size-7 md:size-8 shrink-0 text-white/40 group-hover:text-white transition-transform group-hover:translate-x-1 group-hover:-translate-y-1"
+              />
             </a>
           </div>
         </div>
@@ -159,12 +158,10 @@ const ContactPage = () => {
                 >
                   <div className="flex items-start justify-between gap-3">
                     <social.Icon size={18} aria-hidden />
-                    <span
+                    <ArrowUpRight
                       aria-hidden="true"
-                      className="text-white/40 group-hover:text-white transition-transform group-hover:translate-x-0.5 group-hover:-translate-y-0.5"
-                    >
-                      ↗
-                    </span>
+                      className="size-[18px] shrink-0 text-white/40 group-hover:text-white transition-transform group-hover:translate-x-0.5 group-hover:-translate-y-0.5"
+                    />
                   </div>
                   <div className="flex flex-col gap-1.5">
                     <span className="text-lg md:text-xl font-medium text-white -tracking-[0.01em]">
@@ -193,12 +190,10 @@ const ContactPage = () => {
           className="group mt-10 md:mt-12 inline-flex items-center gap-4 text-xs md:text-sm uppercase tracking-[0.28em] text-white border border-white/25 hover:border-white hover:bg-white/[0.04] px-8 md:px-10 py-4 md:py-5 transition-colors"
         >
           Zobacz repertuar
-          <span
+          <ArrowRight
             aria-hidden="true"
-            className="transition-transform group-hover:translate-x-1"
-          >
-            →
-          </span>
+            className="size-4 shrink-0 transition-transform group-hover:translate-x-1"
+          />
         </Link>
       </section>
 

--- a/src/app/(frontend)/lib/directors.ts
+++ b/src/app/(frontend)/lib/directors.ts
@@ -1,0 +1,143 @@
+import { permanentRedirect } from "next/navigation";
+import { IDirector } from "@/interfaces/IDirectors";
+import { IMovieSummary, PaginatedResponse } from "@/interfaces/IMovies";
+import { IScreeningGroup } from "@/interfaces/IScreenings";
+import { apiFetch, fetchOrNotFound } from "./client";
+
+/**
+ * Upcoming-screenings threshold below which a director page is thin content:
+ * it gets a noindex meta and is left out of the sitemap / static prebuild.
+ * Mirrors the backend's sitemap `directors` filter.
+ */
+export const DIRECTOR_INDEX_THRESHOLD = 3;
+
+interface GetDirectorsParams {
+  page?: number;
+  /** Omit to receive every director in a single page (meta.totalPages = 1). */
+  limit?: number | null;
+  search?: string | null;
+}
+
+interface GetDirectorScreeningsParams {
+  cityId?: string | null;
+  // The API prioritizes city over voivodeship - callers send one of them.
+  voivodeship?: string | null;
+  genreId?: string | null;
+  dateFrom?: string | null;
+  dateTo?: string | null;
+  search?: string | null;
+  limit?: number | null;
+}
+
+const emptyPage = <T>(
+  page: number,
+  limit: number
+): PaginatedResponse<T> => ({
+  data: [],
+  meta: { total: 0, page, limit, totalPages: 0 },
+});
+
+export const getDirectors = async (
+  params: GetDirectorsParams = {}
+): Promise<PaginatedResponse<IDirector>> => {
+  try {
+    return await apiFetch<PaginatedResponse<IDirector>>("/directors", {
+      params: {
+        page: params.page ? params.page.toString() : "",
+        // Empty values are dropped by apiFetch, so omitting `limit` here
+        // makes the API return the full list in one page.
+        limit: params.limit ? params.limit.toString() : "",
+        search: params.search ?? "",
+      },
+    });
+  } catch (error) {
+    console.warn("Falling back to empty directors list:", error);
+    return emptyPage<IDirector>(params.page ?? 1, params.limit ?? 0);
+  }
+};
+
+export const getDirectorBySlug = async (slug: string): Promise<IDirector> =>
+  apiFetch<IDirector>(`/directors/${slug}`);
+
+export const getDirectorPageData = async (
+  slug: string
+): Promise<IDirector> =>
+  fetchOrNotFound(async () => {
+    const director = await getDirectorBySlug(slug);
+
+    // The slug is frozen, so this rarely fires, but a stale link to an old
+    // slug must 301 to the canonical one.
+    if (director.slug !== slug) {
+      permanentRedirect(`/rezyserzy/${director.slug}`);
+    }
+
+    return director;
+  });
+
+export const getMoviesByDirector = async (
+  directorId: number
+): Promise<PaginatedResponse<IMovieSummary>> => {
+  try {
+    return await apiFetch<PaginatedResponse<IMovieSummary>>("/movies", {
+      params: {
+        directorId: directorId.toString(),
+        // A single page covers the whole filmography for the page and JSON-LD.
+        limit: "100",
+      },
+    });
+  } catch (error) {
+    console.warn("Falling back to empty director filmography:", error);
+    return emptyPage<IMovieSummary>(1, 100);
+  }
+};
+
+export const getScreeningsByDirector = async (
+  directorId: number,
+  params: GetDirectorScreeningsParams = {}
+): Promise<IScreeningGroup[]> => {
+  try {
+    const response = await apiFetch<
+      IScreeningGroup[] | PaginatedResponse<IScreeningGroup>
+    >("/screenings", {
+      params: {
+        directorId: directorId.toString(),
+        cityId: params.cityId ?? "",
+        voivodeship: params.voivodeship ?? "",
+        genreId: params.genreId ?? "",
+        dateFrom: params.dateFrom ?? "",
+        dateTo: params.dateTo ?? "",
+        search: params.search ?? "",
+        limit: params.limit ? params.limit.toString() : "",
+      },
+    });
+
+    return Array.isArray(response) ? response : [...response.data];
+  } catch (error) {
+    console.warn("Falling back to empty director screenings list:", error);
+    return [];
+  }
+};
+
+/**
+ * Newest screening `updatedAt` in the director's set - backs the visible
+ * "Repertuar zaktualizowano" label and JSON-LD dateModified. Returns null
+ * when nothing matches or the request fails.
+ */
+export const getDirectorScreeningsLastUpdated = async (
+  directorId: number
+): Promise<Date | null> => {
+  try {
+    const response = await apiFetch<{ updatedAt: string | null }>(
+      "/screenings/last-updated",
+      { params: { directorId: directorId.toString() } }
+    );
+
+    return response.updatedAt ? new Date(response.updatedAt) : null;
+  } catch (error) {
+    console.warn(
+      "Falling back to null director screenings last-updated:",
+      error
+    );
+    return null;
+  }
+};

--- a/src/app/(frontend)/lib/listing-copy.ts
+++ b/src/app/(frontend)/lib/listing-copy.ts
@@ -1,0 +1,154 @@
+import { IScreeningGroup } from "@/interfaces/IScreenings";
+import { IMovieSummary } from "@/interfaces/IMovies";
+import { pluralPl } from "./seo";
+
+/**
+ * Auto-generated intro copy for taxonomy/listing pages that have no editorial
+ * description. Fed only by data the page already fetches (no extra API calls),
+ * it turns near-identical boilerplate into unique, substantive prose per page:
+ * real movie titles, cities and counts. This is the fix for "thin/duplicate
+ * content" on the programmatic city/genre/director pages.
+ *
+ * Grammar guardrail: API names arrive in the nominative. City names are only
+ * ever placed after "takich jak" (which governs the nominative), never after a
+ * preposition that would need a case change. Movie titles are treated as
+ * indeclinable proper nouns.
+ */
+
+// Non-breaking space, built from a char code so no literal U+00A0 sits in the
+// source (keeps the file diffable and avoids invisible whitespace).
+const NBSP = String.fromCharCode(160);
+
+// Bind one-letter Polish words (prepositions/conjunctions) to the next word
+// with a non-breaking space, matching the &nbsp; typography used site-wide.
+const bindOrphans = (text: string): string =>
+  text.replace(/(^|[\s(])([aiouwzAIOUWZ])\s+/g, `$1$2${NBSP}`);
+
+// Polish list joiner: ["A", "B", "C"] -> "A, B i C".
+const joinPl = (items: string[]): string => {
+  if (items.length === 0) return "";
+  if (items.length === 1) return items[0];
+  return `${items.slice(0, -1).join(", ")} i ${items[items.length - 1]}`;
+};
+
+// First `max` distinct movie titles across the screening groups.
+const uniqueTitles = (groups: IScreeningGroup[], max: number): string[] => {
+  const titles: string[] = [];
+  const seen = new Set<string>();
+  for (const group of groups) {
+    const title = group.movie.title?.trim();
+    if (!title || seen.has(title)) continue;
+    seen.add(title);
+    titles.push(title);
+    if (titles.length >= max) break;
+  }
+  return titles;
+};
+
+// Distinct city names across the screening groups (capped at `max`).
+const distinctCities = (groups: IScreeningGroup[], max: number): string[] => {
+  const cities: string[] = [];
+  const seen = new Set<string>();
+  for (const group of groups) {
+    for (const city of group.summary?.cities ?? []) {
+      const name = city?.trim();
+      if (!name || seen.has(name)) continue;
+      seen.add(name);
+      cities.push(name);
+      if (cities.length >= max) return cities;
+    }
+  }
+  return cities;
+};
+
+const totalCityCount = (groups: IScreeningGroup[]): number =>
+  distinctCities(groups, Number.MAX_SAFE_INTEGER).length;
+
+/** Fallback intro for /gatunki/[slug] without an editorial description. */
+export const genreFallbackIntro = (
+  genreNameLower: string,
+  groups: IScreeningGroup[]
+): string => {
+  const movieCount = groups.length;
+  if (movieCount === 0) {
+    return bindOrphans(
+      `Filmy z gatunku ${genreNameLower} pokazywane w polskich kinach ` +
+        `studyjnych. Filtruj po mieście, dacie lub frazie poniżej.`
+    );
+  }
+
+  const titles = uniqueTitles(groups, 3);
+  const cities = distinctCities(groups, 4);
+  const totalCities = totalCityCount(groups);
+
+  const lead =
+    `W repertuarze polskich kin studyjnych znajdziesz ${movieCount} ` +
+    `${pluralPl(movieCount, "film", "filmy", "filmów")} z gatunku ` +
+    genreNameLower;
+  const first =
+    titles.length > 0 ? `${lead}, w tym ${joinPl(titles)}.` : `${lead}.`;
+
+  const second =
+    totalCities >= 2 && cities.length >= 2
+      ? `Seanse odbywają się w ${totalCities} ` +
+        `${pluralPl(totalCities, "mieście", "miastach", "miastach")} w całej ` +
+        `Polsce, takich jak ${joinPl(cities)}.`
+      : "Seanse specjalne, retrospektywy i klasyka filmowa na dużym ekranie.";
+
+  return bindOrphans(`${first} ${second}`);
+};
+
+/** Fallback intro for /miasta/[slug] without an editorial description. */
+export const cityFallbackIntro = (
+  prepCap: "W" | "We",
+  cityLocative: string,
+  cinemasCount: number,
+  groups: IScreeningGroup[]
+): string => {
+  // Bind the preposition explicitly: bindOrphans only catches single letters,
+  // so "We" (two letters) would otherwise keep a breaking space.
+  const first =
+    `${prepCap}${NBSP}${cityLocative} ` +
+    `${pluralPl(cinemasCount, "działa", "działają", "działa")} ${cinemasCount} ` +
+    `${pluralPl(cinemasCount, "kino studyjne", "kina studyjne", "kin studyjnych")}.`;
+
+  const titles = uniqueTitles(groups, 3);
+  const second =
+    titles.length > 0
+      ? `W najbliższym repertuarze ${joinPl(titles)} - seanse specjalne, ` +
+        `retrospektywy i klasyka filmowa na dużym ekranie.`
+      : `Sprawdź nadchodzące seanse specjalne, retrospektywy i klasykę ` +
+        `filmową na dużym ekranie.`;
+
+  return bindOrphans(`${first} ${second}`);
+};
+
+/** Fallback intro for /rezyserzy/[slug] without an editorial bio. */
+export const directorFallbackIntro = (
+  name: string,
+  moviesCount: number,
+  movies: readonly IMovieSummary[]
+): string => {
+  if (moviesCount === 0) {
+    return bindOrphans(
+      `Filmy w reżyserii ${name} pokazywane w polskich kinach studyjnych. ` +
+        `Sprawdź filmografię oraz aktualny repertuar seansów specjalnych, ` +
+        `retrospektyw i klasyki filmowej.`
+    );
+  }
+
+  const titles = movies
+    .slice(0, 4)
+    .map((movie) => `${movie.title} (${movie.productionYear})`);
+
+  const lead =
+    `W repertuarze polskich kin studyjnych znajdziesz ${moviesCount} ` +
+    `${pluralPl(moviesCount, "film", "filmy", "filmów")} w reżyserii ${name}`;
+  const first =
+    titles.length > 0 ? `${lead}, w tym ${joinPl(titles)}.` : `${lead}.`;
+  const second =
+    `Sprawdź filmografię oraz aktualny repertuar seansów specjalnych, ` +
+    `retrospektyw i klasyki filmowej na dużym ekranie.`;
+
+  return bindOrphans(`${first} ${second}`);
+};

--- a/src/app/(frontend)/lib/movies.ts
+++ b/src/app/(frontend)/lib/movies.ts
@@ -8,6 +8,7 @@ import {
 import { IScreening } from "@/interfaces/IScreenings";
 import { apiFetch, fetchOrNotFound } from "./client";
 import { getMovieScreenings } from "./screenings";
+import { tmdbImageUrl } from "./tmdb";
 
 interface GetMoviesParams {
   page?: number;
@@ -51,6 +52,37 @@ export const getMovies = async (
       },
     };
   }
+};
+
+// Safety cap so a misbehaving feed can never loop forever: 50 pages x 100 =
+// 5000 movies, comfortably above the real catalogue.
+const MAX_POSTER_PAGES = 50;
+
+const toAbsolutePosterUrl = (posterUrl: string): string =>
+  posterUrl.startsWith("http") ? posterUrl : tmdbImageUrl(posterUrl, "w780");
+
+/**
+ * slug -> absolute poster URL for every movie that has one. Backs the
+ * <image:image> entries in sitemap.xml. Paginates the movies feed; getMovies
+ * swallows errors into an empty page, so a failed request just ends the loop.
+ */
+export const getMoviePosterMap = async (): Promise<Map<string, string>> => {
+  const posters = new Map<string, string>();
+  let page = 1;
+  let totalPages = 1;
+
+  do {
+    const { data, meta } = await getMovies({ page, limit: 100 });
+    for (const movie of data) {
+      if (movie.posterUrl) {
+        posters.set(movie.slug, toAbsolutePosterUrl(movie.posterUrl));
+      }
+    }
+    totalPages = meta.totalPages || 1;
+    page += 1;
+  } while (page <= totalPages && page <= MAX_POSTER_PAGES);
+
+  return posters;
 };
 
 export const getMovieById = async (id: number): Promise<IMovie> => {

--- a/src/app/(frontend)/lib/og-image.tsx
+++ b/src/app/(frontend)/lib/og-image.tsx
@@ -13,9 +13,12 @@ interface OgImageOptions {
   posterUrl?: string | null;
 }
 
-// Width the poster claims in the poster-dominant movie layout, leaving
-// ~530px for the text column on the right.
-const POSTER_WIDTH = 540;
+// The poster sits as a framed card inside a left panel rather than bleeding
+// full-height: the panel sets the column width, the card keeps a true 2:3
+// movie-poster ratio so it never looks cropped or oversized.
+const POSTER_PANEL_WIDTH = 400;
+const POSTER_CARD_WIDTH = 288;
+const POSTER_CARD_HEIGHT = 432; // 2:3 ratio
 
 // Sized so text stays legible when scaled down to small link embeds
 // (Discord/Slack/Messenger render OG images at roughly 440px wide).
@@ -23,10 +26,10 @@ const POSTER_WIDTH = 540;
 // longest word from clipping; full width otherwise.
 const getTitleSize = (title: string, hasPoster: boolean): number => {
   if (hasPoster) {
-    if (title.length > 24) return 56;
-    if (title.length > 16) return 68;
-    if (title.length > 10) return 80;
-    return 92;
+    if (title.length > 24) return 60;
+    if (title.length > 16) return 72;
+    if (title.length > 10) return 84;
+    return 96;
   }
   if (title.length > 24) return 72;
   if (title.length > 14) return 96;
@@ -52,113 +55,124 @@ export async function buildOgImage({
   // text sits at the bottom of the full-width canvas.
   const bodyJustify = hasPoster ? "center" : "flex-end";
 
-  const infoColumn = (
+  // Top and bottom bars span the full width so the logo and the footer line
+  // always sit flush to the left edge, regardless of the poster.
+  const headerBar = (
     <div
       style={{
         display: "flex",
-        flex: 1,
-        minWidth: 0,
-        flexDirection: "column",
+        alignItems: "center",
+        justifyContent: "space-between",
+        height: 92,
+        padding: `0 ${padX}px`,
+        borderBottom: HAIRLINE,
       }}
     >
-      <div
-        style={{
-          display: "flex",
-          alignItems: "center",
-          justifyContent: "space-between",
-          height: 92,
-          padding: `0 ${padX}px`,
-          borderBottom: HAIRLINE,
-        }}
-      >
-        <div style={{ display: "flex", alignItems: "center", gap: 14 }}>
-          <svg width="34" height="24" viewBox="0 0 28 20">
-            <polygon points="0,8 28,0 28,20 0,12" fill="#ffffff" />
-          </svg>
-          <span
-            style={{
-              fontSize: 36,
-              fontWeight: 700,
-              letterSpacing: "-0.02em",
-            }}
-          >
-            klaps
-          </span>
-        </div>
-        {eyebrow && (
-          <span
-            style={{
-              fontSize: hasPoster ? 18 : 20,
-              textTransform: "uppercase",
-              letterSpacing: "0.3em",
-              color: "rgba(255,255,255,0.45)",
-            }}
-          >
-            {eyebrow}
-          </span>
-        )}
-      </div>
-
-      <div
-        style={{
-          display: "flex",
-          flex: 1,
-          minHeight: 0,
-          flexDirection: "column",
-          justifyContent: bodyJustify,
-          padding: `48px ${padX}px`,
-        }}
-      >
+      <div style={{ display: "flex", alignItems: "center", gap: 14 }}>
+        <svg width="34" height="24" viewBox="0 0 28 20">
+          <polygon points="0,8 28,0 28,20 0,12" fill="#ffffff" />
+        </svg>
         <span
           style={{
-            fontSize: titleSize,
+            fontSize: 36,
             fontWeight: 700,
-            textTransform: "uppercase",
-            letterSpacing: "-0.03em",
-            lineHeight: 0.95,
+            letterSpacing: "-0.02em",
           }}
         >
-          {title}
+          klaps
         </span>
-        {subtitle && (
-          <span
-            style={{
-              marginTop: 24,
-              fontSize: hasPoster ? 30 : 34,
-              color: "rgba(255,255,255,0.6)",
-              lineHeight: 1.35,
-              maxWidth: 980,
-            }}
-          >
-            {subtitle}
-          </span>
-        )}
       </div>
-
-      <div
-        style={{
-          display: "flex",
-          alignItems: "center",
-          justifyContent: "space-between",
-          height: 72,
-          padding: `0 ${padX}px`,
-          borderTop: HAIRLINE,
-        }}
-      >
+      {eyebrow && (
         <span
           style={{
-            fontSize: 19,
+            fontSize: hasPoster ? 18 : 20,
             textTransform: "uppercase",
             letterSpacing: "0.3em",
             color: "rgba(255,255,255,0.45)",
           }}
         >
-          klaps.space
+          {eyebrow}
         </span>
-        <span style={{ fontSize: 28, color: "rgba(255,255,255,0.45)" }}>
-          →
+      )}
+    </div>
+  );
+
+  const footerBar = (
+    <div
+      style={{
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "space-between",
+        height: 72,
+        padding: `0 ${padX}px`,
+        borderTop: HAIRLINE,
+      }}
+    >
+      <span
+        style={{
+          fontSize: 19,
+          textTransform: "uppercase",
+          letterSpacing: "0.3em",
+          color: "rgba(255,255,255,0.45)",
+        }}
+      >
+        klaps.space
+      </span>
+      {/* Inline lucide "arrow-right" path: Satori rasterizes inline SVG but
+          does not reliably render the lucide-react component, so the icon is
+          hand-inlined with an explicit stroke color (no currentColor). */}
+      <svg
+        width="30"
+        height="30"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="rgba(255,255,255,0.45)"
+        strokeWidth={2}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      >
+        <path d="M5 12h14" />
+        <path d="m12 5 7 7-7 7" />
+      </svg>
+    </div>
+  );
+
+  const textBody = (
+    <div
+      style={{
+        display: "flex",
+        flex: 1,
+        minWidth: 0,
+        minHeight: 0,
+        flexDirection: "column",
+        justifyContent: bodyJustify,
+        padding: `48px ${padX}px`,
+      }}
+    >
+      <span
+        style={{
+          fontSize: titleSize,
+          fontWeight: 700,
+          textTransform: "uppercase",
+          letterSpacing: "-0.03em",
+          lineHeight: 0.95,
+        }}
+      >
+        {title}
+      </span>
+      {subtitle && (
+        <span
+          style={{
+            marginTop: 24,
+            fontSize: hasPoster ? 30 : 34,
+            color: "rgba(255,255,255,0.6)",
+            lineHeight: 1.35,
+            maxWidth: 980,
+          }}
+        >
+          {subtitle}
         </span>
-      </div>
+      )}
     </div>
   );
 
@@ -169,27 +183,42 @@ export async function buildOgImage({
           width: "100%",
           height: "100%",
           display: "flex",
+          flexDirection: "column",
           backgroundColor: "#000000",
           color: "#ffffff",
           fontFamily: "Inter",
         }}
       >
-        {posterUrl && (
-          // eslint-disable-next-line @next/next/no-img-element
-          <img
-            src={posterUrl}
-            alt=""
-            width={POSTER_WIDTH}
-            height={630}
-            style={{
-              width: POSTER_WIDTH,
-              height: 630,
-              objectFit: "cover",
-              borderRight: HAIRLINE,
-            }}
-          />
-        )}
-        {infoColumn}
+        {headerBar}
+        <div style={{ display: "flex", flex: 1, minHeight: 0 }}>
+          {posterUrl && (
+            <div
+              style={{
+                display: "flex",
+                width: POSTER_PANEL_WIDTH,
+                alignItems: "center",
+                justifyContent: "center",
+                borderRight: HAIRLINE,
+              }}
+            >
+              {/* eslint-disable-next-line @next/next/no-img-element */}
+              <img
+                src={posterUrl}
+                alt=""
+                width={POSTER_CARD_WIDTH}
+                height={POSTER_CARD_HEIGHT}
+                style={{
+                  width: POSTER_CARD_WIDTH,
+                  height: POSTER_CARD_HEIGHT,
+                  objectFit: "cover",
+                  border: HAIRLINE,
+                }}
+              />
+            </div>
+          )}
+          {textBody}
+        </div>
+        {footerBar}
       </div>
     ),
     {

--- a/src/app/(frontend)/lib/seo.ts
+++ b/src/app/(frontend)/lib/seo.ts
@@ -50,6 +50,19 @@ export const newestUpdatedAtIso = (
   return newest > 0 ? new Date(newest).toISOString() : undefined;
 };
 
+/**
+ * Trim free text (e.g. a bio) to a SERP-friendly length at a word boundary,
+ * adding an ellipsis. Used to derive meta descriptions from longer copy.
+ */
+export const clampText = (text: string, max = 160): string => {
+  const normalized = text.replace(/\s+/g, " ").trim();
+  if (normalized.length <= max) return normalized;
+  const cut = normalized.slice(0, max - 1);
+  const lastSpace = cut.lastIndexOf(" ");
+  const trimmed = lastSpace > max * 0.6 ? cut.slice(0, lastSpace) : cut;
+  return `${trimmed.trimEnd()}…`;
+};
+
 /** Date in Polish long form, e.g. "7 czerwca 2026". Used for the visible
  * "repertoire updated" note that mirrors dateModified in JSON-LD. */
 export const formatPlDate = (date: Date): string =>

--- a/src/app/(frontend)/lib/tmdb.ts
+++ b/src/app/(frontend)/lib/tmdb.ts
@@ -8,3 +8,19 @@ export function tmdbImageUrl(
 ): string {
   return `${TMDB_IMAGE_BASE_URL}/${size}${path}`;
 }
+
+/**
+ * Resolve a person/poster image into a usable absolute URL.
+ * Directors come from TMDB, so photoUrl is normally a profile path
+ * ("/abc.jpg"). next/image only whitelists image.tmdb.org, so values from
+ * any other host return null and the caller falls back to a placeholder.
+ */
+export function resolveTmdbPhotoUrl(
+  photoUrl: string | null | undefined,
+  size: TmdbImageSize = "w342"
+): string | null {
+  if (!photoUrl) return null;
+  if (photoUrl.startsWith("/")) return tmdbImageUrl(photoUrl, size);
+  if (photoUrl.includes("image.tmdb.org")) return photoUrl;
+  return null;
+}

--- a/src/app/(frontend)/mapa-kin/_components/cinema-map-view.tsx
+++ b/src/app/(frontend)/mapa-kin/_components/cinema-map-view.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import Link from "next/link";
+import { ArrowRight } from "lucide-react";
 import {
   Map,
   MapClusterLayer,
@@ -125,16 +126,14 @@ const CinemaMapView: React.FC<CinemaMapViewProps> = ({ cinemas }) => {
                   {selected.address}
                 </p>
               </div>
-              <div className="px-5 py-3 flex items-baseline justify-between gap-2">
+              <div className="px-5 py-3 flex items-center justify-between gap-2">
                 <span className="text-[10px] uppercase tracking-[0.28em] text-white/65 group-hover:text-white transition-colors">
                   Sprawdź repertuar
                 </span>
-                <span
+                <ArrowRight
                   aria-hidden="true"
-                  className="text-white/65 group-hover:text-white transition-transform group-hover:translate-x-1"
-                >
-                  →
-                </span>
+                  className="size-3.5 shrink-0 text-white/65 group-hover:text-white transition-transform group-hover:translate-x-1"
+                />
               </div>
             </Link>
           </MapPopup>

--- a/src/app/(frontend)/miasta/[slug]/page.tsx
+++ b/src/app/(frontend)/miasta/[slug]/page.tsx
@@ -12,6 +12,7 @@ import {
   formatPlDate,
   pluralPl,
 } from "@/lib/seo";
+import { cityFallbackIntro } from "@/lib/listing-copy";
 import Breadcrumbs from "@/components/ui/breadcrumbs";
 import PageHeading from "@/components/ui/page-heading";
 import SiteHeader from "@/components/common/site-header";
@@ -151,19 +152,15 @@ const CityPage = async ({ params }: CityPageProps) => {
         ) : (
           cinemasCount > 0 && (
             // Generated intro keeps description-less city pages from being
-            // thin content - unique copy via the live cinema count.
+            // thin content - unique copy via the live cinema count and the
+            // nearest upcoming titles.
             <p className="mt-8 md:mt-10 max-w-[64ch] text-base md:text-lg text-white/65 leading-relaxed">
-              {wPrep(cityForCopy) === "we" ? "We" : "W"}&nbsp;{cityForCopy}{" "}
-              {pluralPl(cinemasCount, "działa", "działają", "działa")}{" "}
-              {cinemasCount}{" "}
-              {pluralPl(
+              {cityFallbackIntro(
+                wPrep(cityForCopy) === "we" ? "We" : "W",
+                cityForCopy,
                 cinemasCount,
-                "kino studyjne",
-                "kina studyjne",
-                "kin studyjnych"
+                screenings
               )}
-              . Sprawdź nadchodzące seanse specjalne, retrospektywy
-              i&nbsp;klasykę filmową na dużym ekranie.
             </p>
           )
         )}

--- a/src/app/(frontend)/o-projekcie/page.tsx
+++ b/src/app/(frontend)/o-projekcie/page.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import Link from "next/link";
+import { ArrowRight, ArrowUpRight } from "lucide-react";
 import Breadcrumbs from "@/components/ui/breadcrumbs";
 import PageHeading from "@/components/ui/page-heading";
 import SiteHeader from "@/components/common/site-header";
@@ -171,8 +172,8 @@ const AboutPage = () => {
           zajmuje. Jeśli wyświetlany jest przez jeden wieczór w&nbsp;trzech
           kinach w&nbsp;Polsce, wtedy właśnie Klaps jest potrzebny.
         </p>
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-10 md:gap-16">
-          <ul className="flex flex-col gap-3">
+        <div className="grid grid-cols-1 lg:grid-cols-12 gap-10 lg:gap-12">
+          <ul className="lg:col-span-4 flex flex-col gap-3">
             {SCOPE_INCLUDED.map((item) => (
               <li
                 key={item}
@@ -185,7 +186,7 @@ const AboutPage = () => {
               </li>
             ))}
           </ul>
-          <ul className="flex flex-col gap-3">
+          <ul className="lg:col-span-8 flex flex-col gap-3">
             {SCOPE_EXCLUDED.map((item) => (
               <li
                 key={item}
@@ -307,12 +308,10 @@ const AboutPage = () => {
                     <span className="text-xl md:text-2xl font-medium text-white -tracking-[0.01em]">
                       {repo.label}
                     </span>
-                    <span
+                    <ArrowUpRight
                       aria-hidden="true"
-                      className="text-white/40 group-hover:text-white transition-transform group-hover:translate-x-0.5 group-hover:-translate-y-0.5"
-                    >
-                      ↗
-                    </span>
+                      className="size-5 md:size-6 shrink-0 text-white/40 group-hover:text-white transition-transform group-hover:translate-x-0.5 group-hover:-translate-y-0.5"
+                    />
                   </div>
                   <div className="flex flex-col gap-1.5">
                     <span className="text-[10px] uppercase tracking-[0.25em] text-white/40">
@@ -339,12 +338,10 @@ const AboutPage = () => {
           className="group mt-12 md:mt-16 inline-flex items-center gap-4 text-xs md:text-sm uppercase tracking-[0.28em] text-white border border-white/25 hover:border-white hover:bg-white/[0.04] px-8 md:px-10 py-4 md:py-5 transition-colors"
         >
           Zobacz repertuar
-          <span
+          <ArrowRight
             aria-hidden="true"
-            className="transition-transform group-hover:translate-x-1"
-          >
-            →
-          </span>
+            className="size-4 shrink-0 transition-transform group-hover:translate-x-1"
+          />
         </Link>
       </section>
 

--- a/src/app/(frontend)/polityka-prywatnosci/page.tsx
+++ b/src/app/(frontend)/polityka-prywatnosci/page.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import Link from "next/link";
+import { ArrowRight } from "lucide-react";
 import Breadcrumbs from "@/components/ui/breadcrumbs";
 import PageHeading from "@/components/ui/page-heading";
 import SiteHeader from "@/components/common/site-header";
@@ -274,31 +275,27 @@ const PrivacyPolicyPage = () => {
         <div className="mt-8 md:mt-10 grid grid-cols-1 md:grid-cols-2 gap-4 md:gap-5 max-w-[60ch]">
           <Link
             href="/regulamin"
-            className="group flex items-baseline justify-between gap-4 p-5 md:p-6 bg-white/[0.03] hover:bg-white/[0.06] transition-colors"
+            className="group flex items-center justify-between gap-4 p-5 md:p-6 bg-white/[0.03] hover:bg-white/[0.06] transition-colors"
           >
             <span className="text-lg md:text-xl text-white -tracking-[0.01em]">
               Regulamin
             </span>
-            <span
+            <ArrowRight
               aria-hidden="true"
-              className="text-white/40 group-hover:text-white transition-transform group-hover:translate-x-1"
-            >
-              →
-            </span>
+              className="size-5 shrink-0 text-white/40 group-hover:text-white transition-transform group-hover:translate-x-1"
+            />
           </Link>
           <Link
             href="/kontakt"
-            className="group flex items-baseline justify-between gap-4 p-5 md:p-6 bg-white/[0.03] hover:bg-white/[0.06] transition-colors"
+            className="group flex items-center justify-between gap-4 p-5 md:p-6 bg-white/[0.03] hover:bg-white/[0.06] transition-colors"
           >
             <span className="text-lg md:text-xl text-white -tracking-[0.01em]">
               Kontakt
             </span>
-            <span
+            <ArrowRight
               aria-hidden="true"
-              className="text-white/40 group-hover:text-white transition-transform group-hover:translate-x-1"
-            >
-              →
-            </span>
+              className="size-5 shrink-0 text-white/40 group-hover:text-white transition-transform group-hover:translate-x-1"
+            />
           </Link>
         </div>
       </section>

--- a/src/app/(frontend)/regulamin/page.tsx
+++ b/src/app/(frontend)/regulamin/page.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import Link from "next/link";
+import { ArrowRight } from "lucide-react";
 import Breadcrumbs from "@/components/ui/breadcrumbs";
 import PageHeading from "@/components/ui/page-heading";
 import SiteHeader from "@/components/common/site-header";
@@ -247,31 +248,27 @@ const TermsPage = () => {
         <div className="mt-8 md:mt-10 grid grid-cols-1 md:grid-cols-2 gap-4 md:gap-5 max-w-[60ch]">
           <Link
             href="/polityka-prywatnosci"
-            className="group flex items-baseline justify-between gap-4 p-5 md:p-6 bg-white/[0.03] hover:bg-white/[0.06] transition-colors"
+            className="group flex items-center justify-between gap-4 p-5 md:p-6 bg-white/[0.03] hover:bg-white/[0.06] transition-colors"
           >
             <span className="text-lg md:text-xl text-white -tracking-[0.01em]">
               Polityka prywatności
             </span>
-            <span
+            <ArrowRight
               aria-hidden="true"
-              className="text-white/40 group-hover:text-white transition-transform group-hover:translate-x-1"
-            >
-              →
-            </span>
+              className="size-5 shrink-0 text-white/40 group-hover:text-white transition-transform group-hover:translate-x-1"
+            />
           </Link>
           <Link
             href="/kontakt"
-            className="group flex items-baseline justify-between gap-4 p-5 md:p-6 bg-white/[0.03] hover:bg-white/[0.06] transition-colors"
+            className="group flex items-center justify-between gap-4 p-5 md:p-6 bg-white/[0.03] hover:bg-white/[0.06] transition-colors"
           >
             <span className="text-lg md:text-xl text-white -tracking-[0.01em]">
               Kontakt
             </span>
-            <span
+            <ArrowRight
               aria-hidden="true"
-              className="text-white/40 group-hover:text-white transition-transform group-hover:translate-x-1"
-            >
-              →
-            </span>
+              className="size-5 shrink-0 text-white/40 group-hover:text-white transition-transform group-hover:translate-x-1"
+            />
           </Link>
         </div>
       </section>

--- a/src/app/(frontend)/rezyserzy/[slug]/_components/director-repertoire/index.tsx
+++ b/src/app/(frontend)/rezyserzy/[slug]/_components/director-repertoire/index.tsx
@@ -1,0 +1,127 @@
+"use client";
+
+import React, { useMemo } from "react";
+import { useSearchParams } from "next/navigation";
+import { IScreeningGroup } from "@/interfaces/IScreenings";
+import { IGenre } from "@/interfaces/IMovies";
+import {
+  ScreeningsTransitionProvider,
+  useScreeningsTransition,
+} from "@/contexts/screenings-transition-context";
+import { usePreferredCity } from "@/contexts/city-context";
+import { cn } from "@/lib/utils";
+import {
+  filterScreeningGroups,
+  parseGenreIdsParam,
+} from "@/lib/screening-filters";
+import { isVoivodeship } from "@/lib/voivodeships";
+import EmptyState from "@/components/common/empty-state";
+import FilterBar from "../../../../(home)/_components/screenings/filter-bar";
+import ScreeningCard from "../../../../(home)/_components/screenings/screening-card";
+
+interface DirectorRepertoireProps {
+  directorName: string;
+  screenings: IScreeningGroup[];
+  genres: IGenre[];
+}
+
+const DirectorRepertoireInner: React.FC<DirectorRepertoireProps> = ({
+  directorName,
+  screenings,
+  genres,
+}) => {
+  const { isPending } = useScreeningsTransition();
+  const searchParams = useSearchParams();
+  const {
+    cityId: preferredCityId,
+    voivodeship: preferredVoivodeship,
+    isHydrated,
+  } = usePreferredCity();
+
+  // The page is statically cached (ISR) with the director's nationwide
+  // repertoire; filters are applied here after hydration. An explicit
+  // ?city= / ?voivodeship= deep link wins over the stored preference,
+  // with city taking priority over voivodeship.
+  const cityParam = Number(searchParams.get("city"));
+  const urlCityId =
+    !Number.isNaN(cityParam) && cityParam > 0 ? cityParam : null;
+  const voivodeshipParam = searchParams.get("voivodeship");
+  const urlVoivodeship =
+    voivodeshipParam && isVoivodeship(voivodeshipParam)
+      ? voivodeshipParam
+      : null;
+
+  let cityId: number | null = null;
+  let voivodeship: string | null = null;
+  if (urlCityId !== null) {
+    cityId = urlCityId;
+  } else if (urlVoivodeship !== null) {
+    voivodeship = urlVoivodeship;
+  } else if (isHydrated) {
+    cityId = preferredCityId;
+    voivodeship = preferredVoivodeship;
+  }
+
+  const visibleScreenings = useMemo(
+    () =>
+      filterScreeningGroups(screenings, {
+        cityId,
+        voivodeship,
+        genreIds: parseGenreIdsParam(searchParams.get("genres")),
+        dateFrom: searchParams.get("dateFrom"),
+        dateTo: searchParams.get("dateTo"),
+        search: searchParams.get("search"),
+      }),
+    [screenings, cityId, voivodeship, searchParams]
+  );
+
+  return (
+    <section className="border-t border-white/10 px-6 md:px-12 lg:px-16 pt-8 md:pt-12 pb-20 md:pb-28">
+      <h2 className="mb-6 md:mb-8 text-2xl md:text-4xl lg:text-5xl leading-[1.05] -tracking-[0.02em] max-w-[26ch] text-white font-medium">
+        Repertuar - {directorName}
+      </h2>
+
+      <div className="mb-10 md:mb-12">
+        <FilterBar genres={genres} />
+        <div
+          className="mt-8 md:mt-12 -mx-6 md:-mx-12 lg:-mx-16 h-px bg-white/10"
+          aria-hidden="true"
+        />
+      </div>
+
+      <div
+        className={cn(
+          "transition-opacity duration-200",
+          isPending && "opacity-50 pointer-events-none"
+        )}
+      >
+        {visibleScreenings.length === 0 ? (
+          <EmptyState
+            description={
+              <>
+                Brak seansów filmów w&nbsp;reżyserii {directorName} pasujących
+                do wybranych filtrów. Spróbuj zmienić miasto, gatunek lub
+                zakres dat.
+              </>
+            }
+            cta={{ href: "/rezyserzy", label: "Inni reżyserzy" }}
+          />
+        ) : (
+          <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6 xl:grid-cols-8 gap-x-4 md:gap-x-6 gap-y-10 md:gap-y-12">
+            {visibleScreenings.map((group) => (
+              <ScreeningCard key={group.movie.id} group={group} />
+            ))}
+          </div>
+        )}
+      </div>
+    </section>
+  );
+};
+
+const DirectorRepertoire: React.FC<DirectorRepertoireProps> = (props) => (
+  <ScreeningsTransitionProvider>
+    <DirectorRepertoireInner {...props} />
+  </ScreeningsTransitionProvider>
+);
+
+export default DirectorRepertoire;

--- a/src/app/(frontend)/rezyserzy/[slug]/layout.tsx
+++ b/src/app/(frontend)/rezyserzy/[slug]/layout.tsx
@@ -1,0 +1,81 @@
+import { getDirectorBySlug, getMoviesByDirector } from "@/lib/directors";
+import { SITE_URL } from "@/lib/site-config";
+import { newestUpdatedAtIso } from "@/lib/seo";
+import { resolveTmdbPhotoUrl } from "@/lib/tmdb";
+import { IDirector } from "@/interfaces/IDirectors";
+import { IMovieSummary } from "@/interfaces/IMovies";
+import JsonLd from "@/components/common/json-ld";
+
+type DirectorLayoutProps = {
+  children: React.ReactNode;
+  params: Promise<{ slug: string }>;
+};
+
+const buildDirectorJsonLd = (
+  director: IDirector,
+  movies: readonly IMovieSummary[]
+) => {
+  const image = resolveTmdbPhotoUrl(director.photoUrl, "w500");
+  const jsonLd: Record<string, unknown> = {
+    "@context": "https://schema.org",
+    "@type": "Person",
+    name: director.name,
+    jobTitle: "Reżyser",
+    url: `${SITE_URL}/rezyserzy/${director.slug}`,
+  };
+
+  if (image) jsonLd.image = image;
+  if (director.bio) jsonLd.description = director.bio;
+
+  // Freshness signal: newest real data change across the director record and
+  // the filmography. Omitted when nothing carries a timestamp.
+  const dateModified = newestUpdatedAtIso([
+    { updatedAt: director.updatedAt },
+    ...movies,
+  ]);
+  if (dateModified) jsonLd.dateModified = dateModified;
+
+  return jsonLd;
+};
+
+const buildFilmographyJsonLd = (
+  director: IDirector,
+  movies: readonly IMovieSummary[]
+) => ({
+  "@context": "https://schema.org",
+  "@type": "ItemList",
+  name: `Filmografia - ${director.name}`,
+  numberOfItems: movies.length,
+  itemListElement: movies.map((movie, index) => ({
+    "@type": "ListItem",
+    position: index + 1,
+    url: `${SITE_URL}/filmy/${movie.slug}`,
+    name: movie.title,
+  })),
+});
+
+export default async function DirectorLayout({
+  children,
+  params,
+}: Readonly<DirectorLayoutProps>) {
+  const { slug } = await params;
+
+  let director: IDirector;
+  try {
+    director = await getDirectorBySlug(slug);
+  } catch {
+    return children;
+  }
+
+  const { data: movies } = await getMoviesByDirector(director.id);
+
+  return (
+    <>
+      <JsonLd data={buildDirectorJsonLd(director, movies)} />
+      {movies.length > 0 && (
+        <JsonLd data={buildFilmographyJsonLd(director, movies)} />
+      )}
+      {children}
+    </>
+  );
+}

--- a/src/app/(frontend)/rezyserzy/[slug]/opengraph-image.tsx
+++ b/src/app/(frontend)/rezyserzy/[slug]/opengraph-image.tsx
@@ -1,0 +1,23 @@
+import { getDirectorBySlug } from "@/lib/directors";
+import { buildOgImage, OG_SIZE } from "@/lib/og-image";
+import { resolveTmdbPhotoUrl } from "@/lib/tmdb";
+
+export const size = OG_SIZE;
+export const contentType = "image/png";
+export const alt = "Klaps - reżyser";
+
+interface OgImageProps {
+  params: Promise<{ slug: string }>;
+}
+
+export default async function OgImage({ params }: OgImageProps) {
+  const { slug } = await params;
+  const director = await getDirectorBySlug(slug);
+
+  return buildOgImage({
+    eyebrow: "Reżyser",
+    title: director.name,
+    subtitle: "Filmy i seanse w kinach studyjnych",
+    posterUrl: resolveTmdbPhotoUrl(director.photoUrl, "w500"),
+  });
+}

--- a/src/app/(frontend)/rezyserzy/[slug]/page.tsx
+++ b/src/app/(frontend)/rezyserzy/[slug]/page.tsx
@@ -5,24 +5,18 @@ import {
   getDirectors,
   getMoviesByDirector,
   getScreeningsByDirector,
-  getDirectorScreeningsLastUpdated,
   DIRECTOR_INDEX_THRESHOLD,
 } from "@/lib/directors";
 import { getGenres } from "@/lib/genres";
 import { SITE_URL } from "@/lib/site-config";
-import {
-  BASE_OPEN_GRAPH,
-  NOINDEX_FOLLOW,
-  clampText,
-  formatPlDate,
-  pluralPl,
-} from "@/lib/seo";
+import { BASE_OPEN_GRAPH, NOINDEX_FOLLOW, clampText } from "@/lib/seo";
+import { directorFallbackIntro } from "@/lib/listing-copy";
 import Breadcrumbs from "@/components/ui/breadcrumbs";
 import PageHeading from "@/components/ui/page-heading";
 import SiteHeader from "@/components/common/site-header";
 import SectionLoader from "@/components/ui/section-loader";
 import DirectorPhoto from "@/components/common/director-photo";
-import MoviesGrid from "@/app/filmy/_components/movies-grid";
+import RelatedMovies from "@/app/filmy/[slug]/_components/related-movies";
 import Footer from "../../(home)/_components/footer";
 import DirectorRepertoire from "./_components/director-repertoire";
 
@@ -90,13 +84,11 @@ const DirectorPageContent = async ({ slug }: { slug: string }) => {
 
   // Full unfiltered repertoire - DirectorRepertoire narrows it down
   // client-side based on the URL params / preferred city.
-  const [moviesResponse, allGenres, screenings, lastUpdated] =
-    await Promise.all([
-      getMoviesByDirector(director.id),
-      getGenres(),
-      getScreeningsByDirector(director.id),
-      getDirectorScreeningsLastUpdated(director.id),
-    ]);
+  const [moviesResponse, allGenres, screenings] = await Promise.all([
+    getMoviesByDirector(director.id),
+    getGenres(),
+    getScreeningsByDirector(director.id),
+  ]);
 
   const movies = moviesResponse.data;
   const moviesCount = moviesResponse.meta.total || movies.length;
@@ -113,22 +105,24 @@ const DirectorPageContent = async ({ slug }: { slug: string }) => {
       </div>
 
       <header className="px-6 md:px-12 lg:px-16 pt-6 md:pt-8 pb-12 md:pb-16">
-        <div className="grid grid-cols-1 lg:grid-cols-12 gap-10 lg:gap-12 items-start">
-          <div className="lg:col-span-4 xl:col-span-3">
-            <div className="relative aspect-[3/4] max-w-[320px] overflow-hidden border border-white/10 bg-white/[0.03]">
+        <div className="flex flex-col lg:flex-row gap-8 lg:gap-10 items-start">
+          <div className="w-full max-w-[300px] shrink-0">
+            {/* Grayscale portrait matches the B&W directors grid; colour
+                returns on hover for a subtle moment of life. */}
+            <div className="group relative aspect-[3/4] overflow-hidden bg-white/[0.03] ring-1 ring-inset ring-white/10">
               <DirectorPhoto
                 photoUrl={director.photoUrl}
                 name={director.name}
                 width={480}
                 height={640}
                 priority
-                sizes="(max-width: 1024px) 60vw, 320px"
-                className="w-full h-full object-cover"
+                sizes="(max-width: 1024px) 60vw, 300px"
+                className="w-full h-full object-cover grayscale transition-[filter,scale] duration-700 ease-out group-hover:grayscale-0 group-hover:scale-[1.02]"
               />
             </div>
           </div>
 
-          <div className="lg:col-span-8 xl:col-span-9">
+          <div className="flex-1 min-w-0">
             <p className="mb-4 md:mb-5 text-[10px] md:text-xs uppercase tracking-[0.3em] text-white/45">
               Reżyser
             </p>
@@ -141,36 +135,12 @@ const DirectorPageContent = async ({ slug }: { slug: string }) => {
               </p>
             ) : (
               <p className="mt-8 md:mt-10 max-w-[64ch] text-base md:text-lg text-white/55 leading-relaxed">
-                Filmy w&nbsp;reżyserii {director.name} pokazywane w&nbsp;polskich
-                kinach studyjnych. Sprawdź filmografię oraz aktualny repertuar
-                seansów specjalnych, retrospektyw i&nbsp;klasyki filmowej.
-              </p>
-            )}
-            {director.upcomingScreeningsCount > 0 && (
-              // Visible freshness signal: newest screening updatedAt for this
-              // director, mirroring dateModified in JSON-LD.
-              <p className="mt-5 text-[10px] md:text-xs uppercase tracking-[0.25em] text-white/35">
-                Repertuar zaktualizowano:{" "}
-                {formatPlDate(lastUpdated ?? new Date())}
+                {directorFallbackIntro(director.name, moviesCount, movies)}
               </p>
             )}
           </div>
         </div>
       </header>
-
-      {movies.length > 0 && (
-        <section className="border-t border-white/10 px-6 md:px-12 lg:px-16 pt-12 md:pt-16 pb-12 md:pb-16">
-          <div className="mb-8 md:mb-10 flex items-end justify-between gap-6 flex-wrap">
-            <h2 className="text-2xl md:text-4xl lg:text-5xl leading-[1.05] -tracking-[0.02em] max-w-[26ch] text-white font-medium">
-              Filmografia
-            </h2>
-            <span className="text-[10px] md:text-xs uppercase tracking-[0.28em] text-white/45">
-              {moviesCount} {pluralPl(moviesCount, "film", "filmy", "filmów")}
-            </span>
-          </div>
-          <MoviesGrid movies={movies} showHoverOverlay={false} />
-        </section>
-      )}
 
       {/* Suspense: useSearchParams() in the client repertoire needs a
           boundary during static prerender (CSR bailout). */}
@@ -181,6 +151,21 @@ const DirectorPageContent = async ({ slug }: { slug: string }) => {
           genres={allGenres}
         />
       </Suspense>
+
+      {movies.length > 0 && (
+        <section className="border-t border-white/10 px-6 md:px-12 lg:px-16 pt-12 md:pt-16 pb-16 md:pb-24">
+          <div className="grid grid-cols-1 lg:grid-cols-12 gap-y-10 gap-x-8 lg:gap-x-12">
+            <div className="lg:col-span-4">
+              <h2 className="text-3xl md:text-4xl lg:text-5xl font-medium uppercase -tracking-[0.02em] leading-[1] text-white">
+                Filmografia
+              </h2>
+            </div>
+            <div className="lg:col-span-8">
+              <RelatedMovies movies={[...movies]} />
+            </div>
+          </div>
+        </section>
+      )}
     </>
   );
 };

--- a/src/app/(frontend)/rezyserzy/[slug]/page.tsx
+++ b/src/app/(frontend)/rezyserzy/[slug]/page.tsx
@@ -1,0 +1,202 @@
+import React, { Suspense } from "react";
+import { Metadata } from "next";
+import {
+  getDirectorPageData,
+  getDirectors,
+  getMoviesByDirector,
+  getScreeningsByDirector,
+  getDirectorScreeningsLastUpdated,
+  DIRECTOR_INDEX_THRESHOLD,
+} from "@/lib/directors";
+import { getGenres } from "@/lib/genres";
+import { SITE_URL } from "@/lib/site-config";
+import {
+  BASE_OPEN_GRAPH,
+  NOINDEX_FOLLOW,
+  clampText,
+  formatPlDate,
+  pluralPl,
+} from "@/lib/seo";
+import Breadcrumbs from "@/components/ui/breadcrumbs";
+import PageHeading from "@/components/ui/page-heading";
+import SiteHeader from "@/components/common/site-header";
+import SectionLoader from "@/components/ui/section-loader";
+import DirectorPhoto from "@/components/common/director-photo";
+import MoviesGrid from "@/app/filmy/_components/movies-grid";
+import Footer from "../../(home)/_components/footer";
+import DirectorRepertoire from "./_components/director-repertoire";
+
+// ISR: cached HTML revalidated every 5 minutes. The repertoire filters
+// (city, genres, dates, search) are applied client-side in
+// DirectorRepertoire, so this page never reads searchParams or cookies
+// and stays statically cacheable.
+export const revalidate = 300;
+
+type DirectorPageProps = {
+  params: Promise<{ slug: string }>;
+};
+
+// Prebuild only indexable directors (>= threshold upcoming screenings); the
+// long tail renders on demand (dynamicParams defaults to true).
+export const generateStaticParams = async (): Promise<{ slug: string }[]> => {
+  try {
+    const { data } = await getDirectors();
+    return data
+      .filter((d) => d.upcomingScreeningsCount >= DIRECTOR_INDEX_THRESHOLD)
+      .map((d) => ({ slug: d.slug }));
+  } catch {
+    return [];
+  }
+};
+
+export const generateMetadata = async ({
+  params,
+}: DirectorPageProps): Promise<Metadata> => {
+  const { slug } = await params;
+  const director = await getDirectorPageData(slug);
+
+  const title = `${director.name} - filmy i seanse w kinach studyjnych`;
+  const description = director.bio
+    ? clampText(director.bio)
+    : `Filmy w reżyserii ${director.name} na seansach specjalnych w kinach studyjnych w Polsce. Retrospektywy, klasyka filmowa i kino autorskie na dużym ekranie.`;
+  const url = `${SITE_URL}/rezyserzy/${director.slug}`;
+
+  // Thin until the director has enough upcoming screenings; keep those pages
+  // out of the index (matches the sitemap threshold). Query-param duplicates
+  // (filters) on indexable pages are handled by the canonical alone.
+  const noindex = director.upcomingScreeningsCount < DIRECTOR_INDEX_THRESHOLD;
+
+  return {
+    title,
+    description,
+    ...(noindex ? NOINDEX_FOLLOW : { alternates: { canonical: url } }),
+    openGraph: {
+      ...BASE_OPEN_GRAPH,
+      type: "profile",
+      title,
+      description,
+      url,
+    },
+    twitter: {
+      card: "summary_large_image",
+      title,
+      description,
+    },
+  };
+};
+
+const DirectorPageContent = async ({ slug }: { slug: string }) => {
+  const director = await getDirectorPageData(slug);
+
+  // Full unfiltered repertoire - DirectorRepertoire narrows it down
+  // client-side based on the URL params / preferred city.
+  const [moviesResponse, allGenres, screenings, lastUpdated] =
+    await Promise.all([
+      getMoviesByDirector(director.id),
+      getGenres(),
+      getScreeningsByDirector(director.id),
+      getDirectorScreeningsLastUpdated(director.id),
+    ]);
+
+  const movies = moviesResponse.data;
+  const moviesCount = moviesResponse.meta.total || movies.length;
+
+  return (
+    <>
+      <div className="px-6 md:px-12 lg:px-16 pt-6 md:pt-8 pb-4">
+        <Breadcrumbs
+          items={[
+            { name: "Reżyserzy", href: "/rezyserzy" },
+            { name: director.name },
+          ]}
+        />
+      </div>
+
+      <header className="px-6 md:px-12 lg:px-16 pt-6 md:pt-8 pb-12 md:pb-16">
+        <div className="grid grid-cols-1 lg:grid-cols-12 gap-10 lg:gap-12 items-start">
+          <div className="lg:col-span-4 xl:col-span-3">
+            <div className="relative aspect-[3/4] max-w-[320px] overflow-hidden border border-white/10 bg-white/[0.03]">
+              <DirectorPhoto
+                photoUrl={director.photoUrl}
+                name={director.name}
+                width={480}
+                height={640}
+                priority
+                sizes="(max-width: 1024px) 60vw, 320px"
+                className="w-full h-full object-cover"
+              />
+            </div>
+          </div>
+
+          <div className="lg:col-span-8 xl:col-span-9">
+            <p className="mb-4 md:mb-5 text-[10px] md:text-xs uppercase tracking-[0.3em] text-white/45">
+              Reżyser
+            </p>
+            <PageHeading variant="detail" className="max-w-[20ch]">
+              {director.name}
+            </PageHeading>
+            {director.bio ? (
+              <p className="mt-8 md:mt-10 max-w-[64ch] text-base md:text-lg text-white/65 leading-relaxed">
+                {director.bio}
+              </p>
+            ) : (
+              <p className="mt-8 md:mt-10 max-w-[64ch] text-base md:text-lg text-white/55 leading-relaxed">
+                Filmy w&nbsp;reżyserii {director.name} pokazywane w&nbsp;polskich
+                kinach studyjnych. Sprawdź filmografię oraz aktualny repertuar
+                seansów specjalnych, retrospektyw i&nbsp;klasyki filmowej.
+              </p>
+            )}
+            {director.upcomingScreeningsCount > 0 && (
+              // Visible freshness signal: newest screening updatedAt for this
+              // director, mirroring dateModified in JSON-LD.
+              <p className="mt-5 text-[10px] md:text-xs uppercase tracking-[0.25em] text-white/35">
+                Repertuar zaktualizowano:{" "}
+                {formatPlDate(lastUpdated ?? new Date())}
+              </p>
+            )}
+          </div>
+        </div>
+      </header>
+
+      {movies.length > 0 && (
+        <section className="border-t border-white/10 px-6 md:px-12 lg:px-16 pt-12 md:pt-16 pb-12 md:pb-16">
+          <div className="mb-8 md:mb-10 flex items-end justify-between gap-6 flex-wrap">
+            <h2 className="text-2xl md:text-4xl lg:text-5xl leading-[1.05] -tracking-[0.02em] max-w-[26ch] text-white font-medium">
+              Filmografia
+            </h2>
+            <span className="text-[10px] md:text-xs uppercase tracking-[0.28em] text-white/45">
+              {moviesCount} {pluralPl(moviesCount, "film", "filmy", "filmów")}
+            </span>
+          </div>
+          <MoviesGrid movies={movies} showHoverOverlay={false} />
+        </section>
+      )}
+
+      {/* Suspense: useSearchParams() in the client repertoire needs a
+          boundary during static prerender (CSR bailout). */}
+      <Suspense fallback={<SectionLoader label="Ładowanie repertuaru" />}>
+        <DirectorRepertoire
+          directorName={director.name}
+          screenings={screenings}
+          genres={allGenres}
+        />
+      </Suspense>
+    </>
+  );
+};
+
+const DirectorPage = async ({ params }: DirectorPageProps) => {
+  const { slug } = await params;
+
+  return (
+    <main className="bg-black text-white min-h-screen">
+      <SiteHeader />
+      <Suspense fallback={<SectionLoader label="Ładowanie reżysera" />}>
+        <DirectorPageContent slug={slug} />
+      </Suspense>
+      <Footer />
+    </main>
+  );
+};
+
+export default DirectorPage;

--- a/src/app/(frontend)/rezyserzy/_components/director-card.tsx
+++ b/src/app/(frontend)/rezyserzy/_components/director-card.tsx
@@ -11,39 +11,42 @@ interface DirectorCardProps {
 const DirectorCard: React.FC<DirectorCardProps> = ({ director }) => {
   const { name, slug, photoUrl, moviesCount, upcomingScreeningsCount } =
     director;
+  const hasUpcoming = upcomingScreeningsCount > 0;
 
   return (
     <Link
       href={`/rezyserzy/${slug}`}
-      className="group flex flex-col gap-3"
+      className="group flex flex-col gap-2.5"
       aria-label={`Przejdź do reżysera: ${name}`}
     >
-      <div className="relative aspect-[3/4] overflow-hidden border border-white/10 bg-white/[0.03]">
+      {/* Grayscale by default unifies the varied source headshots into the
+          site's B&W palette; colour and a slight zoom return on hover. */}
+      <div className="relative aspect-[3/4] overflow-hidden bg-white/[0.04] ring-1 ring-inset ring-white/0 transition duration-300 group-hover:ring-white/15">
         <DirectorPhoto
           photoUrl={photoUrl}
           name={name}
           width={300}
           height={400}
-          sizes="(max-width: 640px) 50vw, (max-width: 768px) 33vw, (max-width: 1024px) 25vw, 17vw"
-          className="w-full h-full object-cover transition-transform duration-700 ease-out group-hover:scale-[1.02]"
+          sizes="(max-width: 640px) 33vw, (max-width: 768px) 25vw, (max-width: 1024px) 16vw, 12vw"
+          className="w-full h-full object-cover grayscale transition-[filter,scale] duration-700 ease-out group-hover:grayscale-0 group-hover:scale-[1.04]"
         />
       </div>
 
-      <div className="flex flex-col gap-1 min-w-0">
-        <h3 className="text-xs md:text-sm font-semibold uppercase leading-tight tracking-tight text-white line-clamp-2 group-hover:text-white/90">
+      <div className="flex flex-col gap-0.5 min-w-0">
+        <h3 className="text-[11px] md:text-xs font-semibold uppercase leading-tight tracking-tight text-white/85 line-clamp-2 transition-colors group-hover:text-white">
           {name}
         </h3>
-        {(moviesCount > 0 || upcomingScreeningsCount > 0) && (
-          <p className="text-[9px] md:text-[10px] uppercase tracking-[0.18em] text-white/45 truncate">
+        {(moviesCount > 0 || hasUpcoming) && (
+          <p className="text-[9px] md:text-[10px] uppercase tracking-[0.16em] text-white/40 truncate">
             {moviesCount > 0 && (
               <span>
                 {moviesCount} {pluralPl(moviesCount, "film", "filmy", "filmów")}
               </span>
             )}
-            {upcomingScreeningsCount > 0 && (
+            {hasUpcoming && (
               <>
                 {moviesCount > 0 && <span aria-hidden="true"> · </span>}
-                <span className="text-white/70">
+                <span className="text-white/60">
                   {upcomingScreeningsCount}{" "}
                   {pluralPl(
                     upcomingScreeningsCount,

--- a/src/app/(frontend)/rezyserzy/_components/director-card.tsx
+++ b/src/app/(frontend)/rezyserzy/_components/director-card.tsx
@@ -1,0 +1,64 @@
+import React from "react";
+import Link from "next/link";
+import { IDirector } from "@/interfaces/IDirectors";
+import DirectorPhoto from "@/components/common/director-photo";
+import { pluralPl } from "@/lib/seo";
+
+interface DirectorCardProps {
+  director: IDirector;
+}
+
+const DirectorCard: React.FC<DirectorCardProps> = ({ director }) => {
+  const { name, slug, photoUrl, moviesCount, upcomingScreeningsCount } =
+    director;
+
+  return (
+    <Link
+      href={`/rezyserzy/${slug}`}
+      className="group flex flex-col gap-3"
+      aria-label={`Przejdź do reżysera: ${name}`}
+    >
+      <div className="relative aspect-[3/4] overflow-hidden border border-white/10 bg-white/[0.03]">
+        <DirectorPhoto
+          photoUrl={photoUrl}
+          name={name}
+          width={300}
+          height={400}
+          sizes="(max-width: 640px) 50vw, (max-width: 768px) 33vw, (max-width: 1024px) 25vw, 17vw"
+          className="w-full h-full object-cover transition-transform duration-700 ease-out group-hover:scale-[1.02]"
+        />
+      </div>
+
+      <div className="flex flex-col gap-1 min-w-0">
+        <h3 className="text-xs md:text-sm font-semibold uppercase leading-tight tracking-tight text-white line-clamp-2 group-hover:text-white/90">
+          {name}
+        </h3>
+        {(moviesCount > 0 || upcomingScreeningsCount > 0) && (
+          <p className="text-[9px] md:text-[10px] uppercase tracking-[0.18em] text-white/45 truncate">
+            {moviesCount > 0 && (
+              <span>
+                {moviesCount} {pluralPl(moviesCount, "film", "filmy", "filmów")}
+              </span>
+            )}
+            {upcomingScreeningsCount > 0 && (
+              <>
+                {moviesCount > 0 && <span aria-hidden="true"> · </span>}
+                <span className="text-white/70">
+                  {upcomingScreeningsCount}{" "}
+                  {pluralPl(
+                    upcomingScreeningsCount,
+                    "seans",
+                    "seanse",
+                    "seansów"
+                  )}
+                </span>
+              </>
+            )}
+          </p>
+        )}
+      </div>
+    </Link>
+  );
+};
+
+export default DirectorCard;

--- a/src/app/(frontend)/rezyserzy/_components/directors-browser.tsx
+++ b/src/app/(frontend)/rezyserzy/_components/directors-browser.tsx
@@ -94,7 +94,7 @@ const DirectorsBrowser: React.FC<DirectorsBrowserProps> = ({ directors }) => {
           }
         />
       ) : (
-        <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6 gap-x-4 md:gap-x-6 gap-y-8 md:gap-y-12">
+        <div className="grid grid-cols-3 sm:grid-cols-4 md:grid-cols-5 lg:grid-cols-7 xl:grid-cols-8 gap-x-3 gap-y-7 md:gap-x-4 md:gap-y-9">
           {filtered.map((director) => (
             <DirectorCard key={director.id} director={director} />
           ))}

--- a/src/app/(frontend)/rezyserzy/_components/directors-browser.tsx
+++ b/src/app/(frontend)/rezyserzy/_components/directors-browser.tsx
@@ -1,0 +1,107 @@
+"use client";
+
+import React, { useMemo, useState } from "react";
+import { Search, X } from "lucide-react";
+import { IDirector } from "@/interfaces/IDirectors";
+import { cn } from "@/lib/utils";
+import EmptyState from "@/components/common/empty-state";
+import DirectorCard from "./director-card";
+
+interface DirectorsBrowserProps {
+  /** Pre-sorted server-side (directors with upcoming screenings first). */
+  directors: IDirector[];
+}
+
+const DirectorsBrowser: React.FC<DirectorsBrowserProps> = ({ directors }) => {
+  const [query, setQuery] = useState("");
+  const [onlyUpcoming, setOnlyUpcoming] = useState(false);
+
+  // Name search and the "upcoming only" toggle run client-side over the full
+  // list, so neither triggers an extra request.
+  const filtered = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    return directors.filter((director) => {
+      if (onlyUpcoming && director.upcomingScreeningsCount === 0) return false;
+      if (q && !director.name.toLowerCase().includes(q)) return false;
+      return true;
+    });
+  }, [directors, query, onlyUpcoming]);
+
+  const upcomingCount = useMemo(
+    () => directors.filter((d) => d.upcomingScreeningsCount > 0).length,
+    [directors]
+  );
+
+  return (
+    <section className="px-6 md:px-12 lg:px-16 pb-24 md:pb-32">
+      <div className="mb-10 md:mb-12">
+        <div className="flex flex-col md:flex-row md:items-center gap-4 md:gap-6">
+          <div className="relative flex items-center min-w-0 h-9 px-3 border-b border-white/15 focus-within:border-white/45 transition-colors md:w-80">
+            <Search
+              className="size-3.5 text-white/45 shrink-0 pointer-events-none"
+              aria-hidden="true"
+            />
+            <input
+              type="text"
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              placeholder="Szukaj reżysera po nazwisku..."
+              aria-label="Szukaj reżysera"
+              className="ml-3 flex-1 min-w-0 bg-transparent text-[12px] tracking-wide text-white placeholder:text-white/40 outline-none"
+            />
+            {query.length > 0 && (
+              <button
+                type="button"
+                onClick={() => setQuery("")}
+                aria-label="Wyczyść wyszukiwanie"
+                className="ml-2 text-white/40 hover:text-white transition-colors shrink-0"
+              >
+                <X className="size-3.5" />
+              </button>
+            )}
+          </div>
+
+          {upcomingCount > 0 && (
+            <button
+              type="button"
+              onClick={() => setOnlyUpcoming((value) => !value)}
+              aria-pressed={onlyUpcoming}
+              className={cn(
+                "inline-flex items-center justify-between gap-2.5 h-9 px-3.5 border text-[11px] uppercase tracking-wider transition-colors whitespace-nowrap md:ml-auto",
+                onlyUpcoming
+                  ? "border-white text-white"
+                  : "border-white/25 text-white/80 hover:border-white/60 hover:text-white"
+              )}
+            >
+              Tylko z&nbsp;nadchodzącymi seansami
+              <span className="text-white/40">{upcomingCount}</span>
+            </button>
+          )}
+        </div>
+        <div
+          className="mt-8 md:mt-12 -mx-6 md:-mx-12 lg:-mx-16 h-px bg-white/10"
+          aria-hidden="true"
+        />
+      </div>
+
+      {filtered.length === 0 ? (
+        <EmptyState
+          description={
+            <>
+              Brak reżyserów pasujących do&nbsp;wyszukiwania. Spróbuj zmienić
+              frazę.
+            </>
+          }
+        />
+      ) : (
+        <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6 gap-x-4 md:gap-x-6 gap-y-8 md:gap-y-12">
+          {filtered.map((director) => (
+            <DirectorCard key={director.id} director={director} />
+          ))}
+        </div>
+      )}
+    </section>
+  );
+};
+
+export default DirectorsBrowser;

--- a/src/app/(frontend)/rezyserzy/layout.tsx
+++ b/src/app/(frontend)/rezyserzy/layout.tsx
@@ -1,0 +1,68 @@
+import { Metadata } from "next";
+import JsonLd from "@/components/common/json-ld";
+import { getDirectors } from "@/lib/directors";
+import { SITE_URL } from "@/lib/site-config";
+import { BASE_OPEN_GRAPH } from "@/lib/seo";
+import { IDirector } from "@/interfaces/IDirectors";
+
+// Only directors with an active repertoire are worth surfacing in the
+// ItemList; including the full long tail would bloat the payload.
+const buildDirectorsJsonLd = (directors: readonly IDirector[]) => ({
+  "@context": "https://schema.org",
+  "@type": "CollectionPage",
+  name: "Reżyserzy",
+  url: `${SITE_URL}/rezyserzy`,
+  description:
+    "Reżyserzy, których filmy grają na seansach specjalnych w kinach studyjnych w Polsce.",
+  mainEntity: {
+    "@type": "ItemList",
+    numberOfItems: directors.length,
+    itemListElement: directors.map((director, index) => ({
+      "@type": "ListItem",
+      position: index + 1,
+      url: `${SITE_URL}/rezyserzy/${director.slug}`,
+      name: director.name,
+    })),
+  },
+});
+
+export const metadata: Metadata = {
+  title: "Reżyserzy - filmy i seanse w kinach studyjnych",
+  description:
+    "Przeglądaj reżyserów, których kino wraca na duży ekran w polskich kinach studyjnych. Retrospektywy, klasyka filmowa i seanse specjalne.",
+  alternates: {
+    canonical: `${SITE_URL}/rezyserzy`,
+  },
+  openGraph: {
+    ...BASE_OPEN_GRAPH,
+    type: "website",
+    title: "Reżyserzy - kino autorskie w kinach studyjnych",
+    description:
+      "Reżyserzy, których filmy wracają na duży ekran. Seanse specjalne w kinach studyjnych w Polsce.",
+    url: `${SITE_URL}/rezyserzy`,
+  },
+};
+
+export default async function DirectorsLayout({
+  children,
+}: Readonly<{
+  children: React.ReactNode;
+}>) {
+  let directors: IDirector[] = [];
+  try {
+    directors = (await getDirectors()).data.filter(
+      (director) => director.upcomingScreeningsCount > 0
+    );
+  } catch {
+    // JSON-LD is an enhancement - render the page without it on API errors.
+  }
+
+  return (
+    <>
+      {directors.length > 0 && (
+        <JsonLd data={buildDirectorsJsonLd(directors)} />
+      )}
+      {children}
+    </>
+  );
+}

--- a/src/app/(frontend)/rezyserzy/opengraph-image.tsx
+++ b/src/app/(frontend)/rezyserzy/opengraph-image.tsx
@@ -1,0 +1,13 @@
+import { buildOgImage, OG_SIZE } from "@/lib/og-image";
+
+export const size = OG_SIZE;
+export const contentType = "image/png";
+export const alt = "Klaps - Reżyserzy";
+
+export default function OgImage() {
+  return buildOgImage({
+    eyebrow: "Przeglądaj",
+    title: "Reżyserzy",
+    subtitle: "Twórcy, których kino wraca na duży ekran",
+  });
+}

--- a/src/app/(frontend)/rezyserzy/page.tsx
+++ b/src/app/(frontend)/rezyserzy/page.tsx
@@ -1,0 +1,50 @@
+import React from "react";
+import { getDirectors } from "@/lib/directors";
+import { IDirector } from "@/interfaces/IDirectors";
+import Breadcrumbs from "@/components/ui/breadcrumbs";
+import PageHeading, { PageHeadingMuted } from "@/components/ui/page-heading";
+import SiteHeader from "@/components/common/site-header";
+import Footer from "../(home)/_components/footer";
+import DirectorsBrowser from "./_components/directors-browser";
+
+export const revalidate = 300;
+
+// Directors with the most upcoming screenings lead; those without surface
+// further down, ordered by filmography size then name.
+const byRelevance = (a: IDirector, b: IDirector): number =>
+  b.upcomingScreeningsCount - a.upcomingScreeningsCount ||
+  b.moviesCount - a.moviesCount ||
+  a.name.localeCompare(b.name, "pl");
+
+const DirectorsPage = async () => {
+  const { data: directors } = await getDirectors();
+  const sorted = [...directors].sort(byRelevance);
+
+  return (
+    <main className="bg-black text-white min-h-screen">
+      <SiteHeader />
+
+      <div className="px-6 md:px-12 lg:px-16 pt-8 md:pt-10 pb-6">
+        <Breadcrumbs items={[{ name: "Reżyserzy", href: "/rezyserzy" }]} />
+      </div>
+
+      <div className="px-6 md:px-12 lg:px-16 pt-8 md:pt-12 pb-10 md:pb-14">
+        <PageHeading variant="editorial">
+          Reżyserzy.
+          <PageHeadingMuted>Twórcy na dużym ekranie.</PageHeadingMuted>
+        </PageHeading>
+        <p className="mt-4 md:mt-5 max-w-[64ch] text-base md:text-lg text-white/55 leading-relaxed">
+          Reżyserzy, których kino wraca na duży ekran w&nbsp;polskich kinach
+          studyjnych. Retrospektywy, klasyka filmowa i&nbsp;seanse specjalne.
+          Wybierz nazwisko i&nbsp;zobacz filmografię oraz aktualny repertuar.
+        </p>
+      </div>
+
+      <DirectorsBrowser directors={sorted} />
+
+      <Footer />
+    </main>
+  );
+};
+
+export default DirectorsPage;

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -104,7 +104,10 @@
     background-color: black;
     @apply text-foreground;
   }
-  @media (pointer: fine) {
+  /* Hide the native cursor only where the custom cursor actually renders
+     (fine pointer + md and up). Below md the custom cursor is hidden, so the
+     native one must stay visible - including in responsive emulation. */
+  @media (pointer: fine) and (min-width: 768px) {
     *,
     *::before,
     *::after {

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -4,7 +4,7 @@ import { SITE_URL } from "@/lib/site-config";
 // sitemap.ts anywhere under app/ would register as a metadata route.
 import { getSitemapEntries } from "@/lib/sitemap-entries";
 import { getScreenings } from "@/lib/screenings";
-import { getMovies } from "@/lib/movies";
+import { getMovies, getMoviePosterMap } from "@/lib/movies";
 import { getGenres } from "@/lib/genres";
 import { ISitemapEntry } from "@/interfaces/ISitemap";
 
@@ -28,7 +28,10 @@ const toPages = (
   entries: ISitemapEntry[],
   basePath: string,
   changeFrequency: "daily" | "weekly",
-  priority: number
+  priority: number,
+  // Optional per-slug image resolver: returns an absolute image URL to attach
+  // as a sitemap <image:image> entry, or undefined when the slug has none.
+  imageFor?: (slug: string) => string | undefined
 ): MetadataRoute.Sitemap =>
   entries
     .map((entry) => ({
@@ -36,12 +39,16 @@ const toPages = (
       lastModified: toLastModified(entry.updatedAt),
     }))
     .filter(({ slug }) => isValidSlug(slug))
-    .map(({ slug, lastModified }) => ({
-      url: `${SITE_URL}/${basePath}/${encodeURIComponent(slug)}`,
-      lastModified,
-      changeFrequency,
-      priority,
-    }));
+    .map(({ slug, lastModified }) => {
+      const image = imageFor?.(slug);
+      return {
+        url: `${SITE_URL}/${basePath}/${encodeURIComponent(slug)}`,
+        lastModified,
+        changeFrequency,
+        priority,
+        ...(image ? { images: [image] } : {}),
+      };
+    });
 
 // Movie pages without upcoming screenings render with a noindex meta;
 // submitting them would conflict with that signal ("Submitted URL marked
@@ -116,14 +123,17 @@ const sitemap = async (): Promise<MetadataRoute.Sitemap> => {
 
   // Cities arrive pre-filtered by the API (only those with cinemas);
   // movies and genres are cross-checked here against their noindex rules.
-  const [movies, genres] = await Promise.all([
+  // Poster URLs ride along for the movie image sitemap; on failure the map is
+  // empty and movie entries simply ship without an <image:image>.
+  const [movies, genres, posters] = await Promise.all([
     filterMoviesWithScreenings(entries.movies),
     filterNonEmptyGenres(entries.genres),
+    getMoviePosterMap().catch(() => new Map<string, string>()),
   ]);
 
   const allPages = [
     ...staticPages,
-    ...toPages(movies, "filmy", "daily", 0.7),
+    ...toPages(movies, "filmy", "daily", 0.7, (slug) => posters.get(slug)),
     ...toPages(entries.cinemas, "kina", "daily", 0.6),
     ...toPages(entries.cities, "miasta", "daily", 0.6),
     ...toPages(genres, "gatunki", "weekly", 0.5),

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -96,6 +96,7 @@ const sitemap = async (): Promise<MetadataRoute.Sitemap> => {
     { url: `${SITE_URL}/mapa-kin`, changeFrequency: "weekly", priority: 0.7 },
     { url: `${SITE_URL}/miasta`, changeFrequency: "weekly", priority: 0.7 },
     { url: `${SITE_URL}/gatunki`, changeFrequency: "weekly", priority: 0.7 },
+    { url: `${SITE_URL}/rezyserzy`, changeFrequency: "weekly", priority: 0.6 },
     { url: `${SITE_URL}/o-projekcie`, changeFrequency: "monthly", priority: 0.3 },
     { url: `${SITE_URL}/kontakt`, changeFrequency: "monthly", priority: 0.3 },
     { url: `${SITE_URL}/faq`, changeFrequency: "monthly", priority: 0.3 },
@@ -126,6 +127,9 @@ const sitemap = async (): Promise<MetadataRoute.Sitemap> => {
     ...toPages(entries.cinemas, "kina", "daily", 0.6),
     ...toPages(entries.cities, "miasta", "daily", 0.6),
     ...toPages(genres, "gatunki", "weekly", 0.5),
+    // Directors arrive pre-filtered by the API (only those above the
+    // indexing threshold), so no noindex cross-check is needed here.
+    ...toPages(entries.directors ?? [], "rezyserzy", "weekly", 0.5),
   ];
 
   return Array.from(new Map(allPages.map((item) => [item.url, item])).values());


### PR DESCRIPTION
## Summary
- Directors index (/rezyserzy): B&W grayscale grid with colour and zoom on hover, client-side search and "upcoming only" filter.
- Director detail (/rezyserzy/[slug]): photo, bio, repertoire (combinable city/genre/date filters), filmography matching the related-movies layout. noindex + canonical 301 + Person JSON-LD.
- Movie page + hero: director credits link to /rezyserzy/[slug] via IMoviePerson.slug.
- listing-copy: data-driven fallback intros for city/genre/director pages.
- Sitemap: movie image entries and director routes; nav/footer links to /rezyserzy.

## Verification
- bun tsc --noEmit: clean
- bun eslint: clean
- Pages render 200 locally.