### PR TITLE
ci: use PROJECT_DIR secret with DEPLOY_DIR fallback

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -66,7 +66,7 @@ jobs:
     needs: [setup, build-and-push]
     environment: ${{ needs.setup.outputs.environment }}
     env:
-      DEPLOY_DIR: ${{ secrets.DEPLOY_DIR }}/frontend/${{ needs.setup.outputs.env_suffix }}
+      DEPLOY_DIR: ${{ secrets.PROJECT_DIR || secrets.DEPLOY_DIR }}/frontend/${{ needs.setup.outputs.env_suffix }}
       IMAGE_TAG: ${{ needs.setup.outputs.image_tag }}
       ENV_SUFFIX: ${{ needs.setup.outputs.env_suffix }}
       DOMAIN: ${{ secrets.DOMAIN }}


### PR DESCRIPTION
Unifies the VPS base-directory secret name across repos (api.klaps.space and klaps.radar use PROJECT_DIR). Falls back to the existing DEPLOY_DIR secret, so this is safe to merge before the org-level PROJECT_DIR secret exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)