### PR TITLE
ci: store branch rulesets as versioned JSON

### DIFF
--- a/.github/rulesets/README.md
+++ b/.github/rulesets/README.md
@@ -1,0 +1,14 @@
+# Branch rulesets
+
+Wersjonowane zrodlo prawdy dla rulesetow GitHuba (Settings -> Rules -> Rulesets).
+GitHub nie czyta tych plikow automatycznie - po zmianie zastosuj przez gh:
+
+```bash
+gh api repos/klaps-hq/klaps.space/rulesets/13250046 --method PUT --input .github/rulesets/main.json
+gh api repos/klaps-hq/klaps.space/rulesets/13250532 --method PUT --input .github/rulesets/dev.json
+```
+
+| Plik        | Ruleset                   | ID       |
+| ----------- | ------------------------- | -------- |
+| `main.json` | main - PR required checks | 13250046 |
+| `dev.json`  | dev - PR required checks  | 13250532 |

--- a/.github/rulesets/dev.json
+++ b/.github/rulesets/dev.json
@@ -1,0 +1,70 @@
+{
+    "name":  "dev - PR required checks",
+    "target":  "branch",
+    "enforcement":  "active",
+    "conditions":  {
+                       "ref_name":  {
+                                        "exclude":  [
+
+                                                    ],
+                                        "include":  [
+                                                        "refs/heads/dev"
+                                                    ]
+                                    }
+                   },
+    "rules":  [
+                  {
+                      "type":  "deletion"
+                  },
+                  {
+                      "type":  "non_fast_forward"
+                  },
+                  {
+                      "type":  "pull_request",
+                      "parameters":  {
+                                         "required_approving_review_count":  0,
+                                         "dismiss_stale_reviews_on_push":  false,
+                                         "required_reviewers":  [
+
+                                                                ],
+                                         "require_code_owner_review":  false,
+                                         "require_last_push_approval":  false,
+                                         "required_review_thread_resolution":  true,
+                                         "allowed_merge_methods":  [
+                                                                       "merge",
+                                                                       "squash",
+                                                                       "rebase"
+                                                                   ]
+                                     }
+                  },
+                  {
+                      "type":  "required_status_checks",
+                      "parameters":  {
+                                         "strict_required_status_checks_policy":  false,
+                                         "do_not_enforce_on_create":  false,
+                                         "required_status_checks":  [
+                                                                        {
+                                                                            "context":  "build",
+                                                                            "integration_id":  15368
+                                                                        },
+                                                                        {
+                                                                            "context":  "PR Title (Conventional)",
+                                                                            "integration_id":  15368
+                                                                        },
+                                                                        {
+                                                                            "context":  "typecheck",
+                                                                            "integration_id":  15368
+                                                                        },
+                                                                        {
+                                                                            "context":  "Commit Messages (Conventional)",
+                                                                            "integration_id":  15368
+                                                                        },
+                                                                        {
+                                                                            "context":  "Auto-format PR title",
+                                                                            "integration_id":  15368
+                                                                        }
+                                                                    ]
+                                     }
+                  }
+              ]
+}

--- a/.github/rulesets/main.json
+++ b/.github/rulesets/main.json
@@ -1,0 +1,70 @@
+{
+    "name":  "main - PR required checks",
+    "target":  "branch",
+    "enforcement":  "active",
+    "conditions":  {
+                       "ref_name":  {
+                                        "exclude":  [
+
+                                                    ],
+                                        "include":  [
+                                                        "refs/heads/main"
+                                                    ]
+                                    }
+                   },
+    "rules":  [
+                  {
+                      "type":  "deletion"
+                  },
+                  {
+                      "type":  "non_fast_forward"
+                  },
+                  {
+                      "type":  "pull_request",
+                      "parameters":  {
+                                         "required_approving_review_count":  0,
+                                         "dismiss_stale_reviews_on_push":  false,
+                                         "required_reviewers":  [
+
+                                                                ],
+                                         "require_code_owner_review":  false,
+                                         "require_last_push_approval":  false,
+                                         "required_review_thread_resolution":  true,
+                                         "allowed_merge_methods":  [
+                                                                       "merge",
+                                                                       "squash",
+                                                                       "rebase"
+                                                                   ]
+                                     }
+                  },
+                  {
+                      "type":  "required_status_checks",
+                      "parameters":  {
+                                         "strict_required_status_checks_policy":  false,
+                                         "do_not_enforce_on_create":  false,
+                                         "required_status_checks":  [
+                                                                        {
+                                                                            "context":  "Commit Messages (Conventional)",
+                                                                            "integration_id":  15368
+                                                                        },
+                                                                        {
+                                                                            "context":  "typecheck",
+                                                                            "integration_id":  15368
+                                                                        },
+                                                                        {
+                                                                            "context":  "PR Title (Conventional)",
+                                                                            "integration_id":  15368
+                                                                        },
+                                                                        {
+                                                                            "context":  "build",
+                                                                            "integration_id":  15368
+                                                                        },
+                                                                        {
+                                                                            "context":  "Auto-format PR title",
+                                                                            "integration_id":  15368
+                                                                        }
+                                                                    ]
+                                     }
+                  }
+              ]
+}


### PR DESCRIPTION
Exported GitHub branch rulesets (main + dev) into .github/rulesets/ as the versioned source of truth, with gh apply instructions.