### PR TITLE
feat: surface social media links in footer

### DIFF
--- a/src/app/(frontend)/(home)/_components/footer/index.tsx
+++ b/src/app/(frontend)/(home)/_components/footer/index.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import Image from "next/image";
 import Link from "next/link";
 import { ArrowUpRight } from "lucide-react";
+import SocialLinks from "@/components/common/social-links";
 import WilhelmEgg from "./wilhelm-egg";
 
 const NAV_COLUMNS = [
@@ -61,12 +62,15 @@ const Footer: React.FC = () => {
           ))}
         </div>
 
-        <p className="mb-8 max-w-[64ch] text-xs md:text-sm text-white/45 leading-relaxed">
-          Klaps to ogólnopolski przewodnik po seansach specjalnych, klasyce
-          filmowej i&nbsp;retrospektywach w&nbsp;kinach studyjnych. Repertuar,
-          filmy i&nbsp;kina w&nbsp;jednym miejscu, bezpłatnie i&nbsp;bez
-          rejestracji.
-        </p>
+        <div className="mb-8 flex flex-col gap-8 md:flex-row md:items-end md:justify-between">
+          <p className="max-w-[64ch] text-xs md:text-sm text-white/45 leading-relaxed">
+            Klaps to ogólnopolski przewodnik po seansach specjalnych, klasyce
+            filmowej i&nbsp;retrospektywach w&nbsp;kinach studyjnych. Repertuar,
+            filmy i&nbsp;kina w&nbsp;jednym miejscu, bezpłatnie i&nbsp;bez
+            rejestracji.
+          </p>
+          <SocialLinks className="shrink-0" />
+        </div>
 
         <div className="flex items-center justify-between gap-4 pt-8 border-t border-white/10 text-[10px] md:text-xs uppercase tracking-[0.2em] text-white/50">
           <span>&copy; {currentYear} Klaps</span>

--- a/src/app/(frontend)/components/common/social-links.tsx
+++ b/src/app/(frontend)/components/common/social-links.tsx
@@ -28,7 +28,6 @@ const SOCIAL_ITEMS: SocialItem[] = [
     id: "x",
     label: "X",
     href: SOCIAL_LINKS.x,
-    showLabel: false,
     Icon: FaXTwitter,
   },
   {
@@ -58,17 +57,16 @@ const SocialLinks: React.FC<SocialLinksProps> = ({
   iconSize = 13,
 }) => {
   return (
-    <div className={cn("flex flex-wrap items-center gap-2", className)}>
+    <div className={cn("flex flex-wrap items-center gap-x-6 gap-y-3", className)}>
       {SOCIAL_ITEMS.map(({ id, label, href, showLabel = true, Icon }) => (
         <a
           key={id}
           href={href}
           target="_blank"
-          rel="noopener noreferrer nofollow"
+          rel="noopener noreferrer"
           aria-label={`Klaps na ${label}`}
           className={cn(
-            "inline-flex h-8 items-center border border-white/15 bg-white/2 text-[10px] uppercase tracking-[0.16em] text-white/65 transition-all hover:border-blood-red/70 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blood-red focus-visible:ring-offset-2",
-            showLabel ? "gap-2 px-3" : "px-2.5",
+            "inline-flex items-center gap-2 text-[10px] uppercase tracking-[0.16em] text-white/55 transition-colors hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-offset-2",
             focusRingOffsetClassName,
             linkClassName
           )}


### PR DESCRIPTION
## Summary

- Mount the existing (previously unused) `SocialLinks` component in the footer, in the row with the project description (description left, links right).
- Restyle the links from bordered chips to flat typographic icon-and-label links matching the rest of the footer (uppercase, tracked, white on hover). The X link now shows its label like the others.
- Drop `rel=nofollow` from our own profile links so they corroborate the `Organization.sameAs` entries already declared in JSON-LD.