### PR TITLE
feat: drop blood-red accent for monochrome palette and report web vitals

### DIFF
--- a/src/app/(frontend)/(home)/_components/hero/movie-meta.tsx
+++ b/src/app/(frontend)/(home)/_components/hero/movie-meta.tsx
@@ -47,7 +47,7 @@ const MovieMeta: React.FC<MovieMetaProps> = ({
             <React.Fragment key={genre.id}>
               <Link
                 href={buildGenreHref(genre)}
-                className="hover:text-blood-red transition-colors duration-200"
+                className="hover:text-white transition-colors duration-200"
               >
                 {genre.name}
               </Link>

--- a/src/app/(frontend)/(home)/_components/screenings-section/screening-hover-overlay.tsx
+++ b/src/app/(frontend)/(home)/_components/screenings-section/screening-hover-overlay.tsx
@@ -4,7 +4,7 @@ import { Ticket } from "lucide-react";
 const ScreeningHoverOverlay: React.FC = () => (
   <div className="absolute inset-0 bg-linear-to-t from-black/80 via-transparent to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-300 flex items-end p-3">
     <span className="flex items-end gap-1.5 text-xs text-white font-medium">
-      <Ticket className="size-3.5 text-blood-red" aria-hidden="true" />
+      <Ticket className="size-3.5 text-white" aria-hidden="true" />
       <span>Sprawdź seanse i kina</span>
     </span>
   </div>

--- a/src/app/(frontend)/(home)/_components/screenings-section/screening-summary.tsx
+++ b/src/app/(frontend)/(home)/_components/screenings-section/screening-summary.tsx
@@ -17,7 +17,7 @@ const ScreeningSummary: React.FC<ScreeningSummaryProps> = ({
   return (
     <div className="flex items-center gap-3 text-xs text-white/50 mt-1">
       <span className="flex items-center gap-1">
-        <Clock className="size-3 text-blood-red" aria-hidden="true" />
+        <Clock className="size-3 text-white/50" aria-hidden="true" />
         <span>
           {screeningsCount} {screeningsCount === 1 ? "seans" : "seansów"}
         </span>
@@ -25,7 +25,7 @@ const ScreeningSummary: React.FC<ScreeningSummaryProps> = ({
       
       {cinemasCount > 1 && (
         <span className="flex items-center gap-1">
-          <Ticket className="size-3 text-blood-red" aria-hidden="true" />
+          <Ticket className="size-3 text-white/50" aria-hidden="true" />
           <span>
             {cinemasCount} {cinemasCount === 1 ? "kino" : "kin"}
           </span>

--- a/src/app/(frontend)/components/common/cinema-list-item.tsx
+++ b/src/app/(frontend)/components/common/cinema-list-item.tsx
@@ -11,9 +11,9 @@ const CinemaListItem: React.FC<CinemaListItemProps> = ({ cinema }) => {
     <li>
       <Link
         href={`/kina/${cinema.slug}`}
-        className="group flex items-baseline justify-between gap-4 py-3 transition-colors duration-200 hover:text-blood-red focus-visible:text-blood-red focus-visible:outline-none"
+        className="group flex items-baseline justify-between gap-4 py-3 transition-colors duration-200 hover:text-white focus-visible:text-white focus-visible:outline-none"
       >
-        <span className="text-neutral-300 text-base md:text-lg leading-snug group-hover:text-blood-red group-focus-visible:text-blood-red transition-colors duration-200">
+        <span className="text-neutral-300 text-base md:text-lg leading-snug group-hover:text-white group-focus-visible:text-white transition-colors duration-200">
           {cinema.name}
         </span>
 

--- a/src/app/(frontend)/components/common/logo.tsx
+++ b/src/app/(frontend)/components/common/logo.tsx
@@ -7,9 +7,9 @@ const Logo: React.FC = () => {
   return (
     <Link
       href="/"
-      className="inline-flex flex-col gap-0.5 transition-opacity hover:opacity-90 focus-visible:outline focus-visible:ring-2 focus-visible:ring-blood-red focus-visible:ring-offset-2 focus-visible:ring-offset-black rounded-sm"
+      className="inline-flex flex-col gap-0.5 transition-opacity hover:opacity-90 focus-visible:outline focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-offset-2 focus-visible:ring-offset-black rounded-sm"
     >
-      <span className="text-4xl font-monoton uppercase text-blood-red drop-shadow-[0_0_1px_rgba(255,255,255,0.3)]">
+      <span className="text-4xl font-monoton uppercase text-white">
         Klaps
       </span>
 

--- a/src/app/(frontend)/components/common/scroll-to-top.tsx
+++ b/src/app/(frontend)/components/common/scroll-to-top.tsx
@@ -27,7 +27,7 @@ const ScrollToTop: React.FC = () => {
       type="button"
       onClick={handleClick}
       className={cn(
-        "fixed bottom-6 right-6 md:bottom-8 md:right-8 z-50 flex items-center justify-center size-10 md:size-12 bg-blood-red text-white transition-all duration-300 hover:bg-blood-red/80 cursor-pointer",
+        "fixed bottom-6 right-6 md:bottom-8 md:right-8 z-50 flex items-center justify-center size-10 md:size-12 bg-white text-black transition-all duration-300 hover:bg-white/80 cursor-pointer",
         isVisible
           ? "opacity-100 translate-y-0"
           : "opacity-0 translate-y-4 pointer-events-none"

--- a/src/app/(frontend)/components/common/search-input.tsx
+++ b/src/app/(frontend)/components/common/search-input.tsx
@@ -47,7 +47,7 @@ const SearchInput: React.FC<SearchInputProps> = ({
         onChange={handleChange}
         onKeyDown={handleKeyDown}
         placeholder={placeholder}
-        className="w-full h-10 md:h-9 pl-10 pr-9 bg-white/5 border border-white/20 text-white text-sm tracking-wide placeholder:text-white/40 outline-none transition-colors duration-200 focus:border-blood-red focus:bg-white/[0.07]"
+        className="w-full h-10 md:h-9 pl-10 pr-9 bg-white/5 border border-white/20 text-white text-sm tracking-wide placeholder:text-white/40 outline-none transition-colors duration-200 focus:border-white/60 focus:bg-white/[0.07]"
       />
 
       {value.length > 0 && (

--- a/src/app/(frontend)/components/common/section-header.tsx
+++ b/src/app/(frontend)/components/common/section-header.tsx
@@ -13,7 +13,7 @@ const SectionHeader: React.FC<SectionHeaderProps> = ({
 }) => {
   return (
     <h2 className="flex flex-col gap-1 max-w-fit">
-      <span className="text-blood-red text-sm uppercase tracking-widest">
+      <span className="text-white/60 text-sm uppercase tracking-widest">
         {prefix}
       </span>
 

--- a/src/app/(frontend)/components/common/web-vitals-reporter.tsx
+++ b/src/app/(frontend)/components/common/web-vitals-reporter.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import { useReportWebVitals } from "next/web-vitals";
+
+// Reports Core Web Vitals (LCP, INP, CLS, FCP, TTFB) to GA4 as events so we
+// get real field data without depending on CrUX sampling (which needs traffic
+// the site does not yet have). Mounted only when GA is configured; it also
+// no-ops until gtag exists, so it never sends before analytics consent.
+const WebVitalsReporter = () => {
+  useReportWebVitals((metric) => {
+    if (typeof window === "undefined") return;
+    const gtag = (
+      window as unknown as { gtag?: (...args: unknown[]) => void }
+    ).gtag;
+    if (typeof gtag !== "function") return;
+
+    gtag("event", metric.name, {
+      // GA4 event value must be an integer. CLS is sub-1, so scale it up.
+      value: Math.round(
+        metric.name === "CLS" ? metric.value * 1000 : metric.value
+      ),
+      metric_id: metric.id,
+      metric_value: metric.value,
+      metric_rating: metric.rating,
+      non_interaction: true,
+    });
+  });
+
+  return null;
+};
+
+export default WebVitalsReporter;

--- a/src/app/(frontend)/components/ui/badge.tsx
+++ b/src/app/(frontend)/components/ui/badge.tsx
@@ -7,10 +7,10 @@ const badgeVariants = cva(
   {
     variants: {
       variant: {
-        default: "bg-blood-red text-white",
-        outline: "border-2 border-blood-red text-blood-red bg-transparent",
+        default: "bg-white text-black",
+        outline: "border-2 border-white text-white bg-transparent",
         label:
-          "border-l-4 border-l-blood-red bg-transparent text-white pl-4 py-1.5",
+          "border-l-4 border-l-white bg-transparent text-white pl-4 py-1.5",
       },
     },
     defaultVariants: {

--- a/src/app/(frontend)/components/ui/breadcrumbs.tsx
+++ b/src/app/(frontend)/components/ui/breadcrumbs.tsx
@@ -52,7 +52,7 @@ const Breadcrumbs: React.FC<BreadcrumbsProps> = ({ items }) => {
                 ) : (
                   <Link
                     href={item.href ?? "/"}
-                    className="max-w-[220px] truncate text-white/45 transition-colors duration-300 hover:text-white/85 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-blood-red/80 md:max-w-[320px]"
+                    className="max-w-[220px] truncate text-white/45 transition-colors duration-300 hover:text-white/85 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-white/80 md:max-w-[320px]"
                     tabIndex={0}
                     aria-label={`Przejdź do ${item.name}`}
                   >

--- a/src/app/(frontend)/components/ui/button.tsx
+++ b/src/app/(frontend)/components/ui/button.tsx
@@ -12,9 +12,9 @@ const buttonVariants = cva(
         default:
           "rounded-md bg-primary text-primary-foreground hover:bg-primary/90 focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
         primary:
-          "rounded-none bg-blood-red text-white font-semibold uppercase tracking-[0.2em] shadow-[0_0_0_0_rgba(220,19,1,0)] hover:bg-blood-red/90 hover:-translate-y-0.5 hover:shadow-[0_10px_24px_-10px_rgba(220,19,1,0.75)]",
+          "rounded-none bg-white text-black font-semibold uppercase tracking-[0.2em] shadow-[0_0_0_0_rgba(255,255,255,0)] hover:bg-white/90 hover:-translate-y-0.5 hover:shadow-[0_10px_24px_-10px_rgba(255,255,255,0.45)]",
         secondary:
-          "rounded-none border-2 border-blood-red bg-transparent text-white font-semibold uppercase tracking-[0.2em] hover:bg-blood-red hover:text-white hover:-translate-y-0.5 hover:shadow-[0_10px_24px_-10px_rgba(220,19,1,0.6)]",
+          "rounded-none border-2 border-white bg-transparent text-white font-semibold uppercase tracking-[0.2em] hover:bg-white hover:text-black hover:-translate-y-0.5 hover:shadow-[0_10px_24px_-10px_rgba(255,255,255,0.35)]",
         destructive:
           "rounded-md bg-destructive text-white hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60",
         outline:
@@ -24,7 +24,7 @@ const buttonVariants = cva(
         link: "text-primary underline-offset-4 hover:underline",
         tag: "rounded-none bg-white/5 text-white/80 uppercase tracking-wider border border-white/20 hover:bg-white/10 hover:text-white hover:border-white/40",
         "tag-active":
-          "rounded-none bg-blood-red/15 text-blood-red uppercase tracking-wider border border-blood-red/50",
+          "rounded-none bg-white text-black uppercase tracking-wider border border-white",
       },
       size: {
         default: "h-9 px-4 py-2 has-[>svg]:px-3",

--- a/src/app/(frontend)/components/ui/radio-group.tsx
+++ b/src/app/(frontend)/components/ui/radio-group.tsx
@@ -27,7 +27,7 @@ const radioGroupItemVariants = cva(
       variant: {
         default:
           "border-input text-primary focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 aspect-square size-4 shrink-0 rounded-full border shadow-xs transition-[color,box-shadow] focus-visible:ring-[3px]",
-        tag: "rounded-none bg-white/5 text-white/80 uppercase tracking-wider border border-white/20 hover:bg-white/10 hover:text-white hover:border-white/40 data-[state=checked]:bg-blood-red/15 data-[state=checked]:text-blood-red data-[state=checked]:border-blood-red/50 data-[state=checked]:cursor-default",
+        tag: "rounded-none bg-white/5 text-white/80 uppercase tracking-wider border border-white/20 hover:bg-white/10 hover:text-white hover:border-white/40 data-[state=checked]:bg-white data-[state=checked]:text-black data-[state=checked]:border-white data-[state=checked]:cursor-default",
       },
       size: {
         default: "",

--- a/src/app/(frontend)/components/ui/read-more-link.tsx
+++ b/src/app/(frontend)/components/ui/read-more-link.tsx
@@ -18,7 +18,7 @@ const LinkWithArrow: React.FC<LinkWithArrowProps> = ({
     <Link
       href={href}
       className={cn(
-        "group inline-flex items-center gap-2 text-neutral-400 text-sm uppercase tracking-widest transition-[color,transform] duration-300 hover:text-blood-red hover:-translate-y-0.5 focus-visible:text-blood-red focus-visible:outline-none",
+        "group inline-flex items-center gap-2 text-neutral-400 text-sm uppercase tracking-widest transition-[color,transform] duration-300 hover:text-white hover:-translate-y-0.5 focus-visible:text-white focus-visible:outline-none",
         className
       )}
     >

--- a/src/app/(frontend)/filmy/_components/movie-card.tsx
+++ b/src/app/(frontend)/filmy/_components/movie-card.tsx
@@ -33,7 +33,7 @@ const MovieCard: React.FC<MovieCardProps> = ({
       <div className="relative">
         <Link
           href={`/filmy/${movie.slug}`}
-          className="block overflow-hidden border border-white/10 transition-transform duration-300 group-hover:scale-[1.02] w-full aspect-2/3 focus-visible:outline focus-visible:ring-2 focus-visible:ring-blood-red focus-visible:ring-offset-2 focus-visible:ring-offset-black"
+          className="block overflow-hidden border border-white/10 transition-transform duration-300 group-hover:scale-[1.02] w-full aspect-2/3 focus-visible:outline focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-offset-2 focus-visible:ring-offset-black"
         >
           <MoviePoster
             posterUrl={movie.posterUrl ?? ""}
@@ -52,7 +52,7 @@ const MovieCard: React.FC<MovieCardProps> = ({
         <h3 className="text-lg font-semibold uppercase tracking-wide">
           <Link
             href={`/filmy/${movie.slug}`}
-            className="text-white hover:text-blood-red transition-colors line-clamp-2 focus-visible:outline focus-visible:ring-2 focus-visible:ring-blood-red focus-visible:ring-offset-2 focus-visible:ring-offset-black"
+            className="text-white hover:text-white/70 transition-colors line-clamp-2 focus-visible:outline focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-offset-2 focus-visible:ring-offset-black"
           >
             {movie.title}
           </Link>

--- a/src/app/(frontend)/gatunki/_components/genre-link-item.tsx
+++ b/src/app/(frontend)/gatunki/_components/genre-link-item.tsx
@@ -11,9 +11,9 @@ const GenreLinkItem: React.FC<GenreLinkItemProps> = ({ genre }) => {
     <li className="md:border-b md:border-neutral-800">
       <Link
         href={`/gatunki/${genre.slug}`}
-        className="group flex items-baseline gap-4 py-3 transition-colors duration-200 hover:text-blood-red focus-visible:text-blood-red focus-visible:outline-none"
+        className="group flex items-baseline gap-4 py-3 transition-colors duration-200 hover:text-white focus-visible:text-white focus-visible:outline-none"
       >
-        <span className="text-neutral-300 text-base md:text-lg leading-snug group-hover:text-blood-red group-focus-visible:text-blood-red transition-colors duration-200">
+        <span className="text-neutral-300 text-base md:text-lg leading-snug group-hover:text-white group-focus-visible:text-white transition-colors duration-200">
           {genre.name}
         </span>
       </Link>

--- a/src/app/(frontend)/miasta/[slug]/_components/city-stats.tsx
+++ b/src/app/(frontend)/miasta/[slug]/_components/city-stats.tsx
@@ -22,7 +22,7 @@ const CityStats: React.FC<CityStatsProps> = ({
       {stats.map((stat) => (
         <div
           key={stat.label}
-          className="flex flex-col gap-1 border-l-4 border-l-blood-red pl-4"
+          className="flex flex-col gap-1 border-l-4 border-l-white pl-4"
         >
           <dt className="text-neutral-500 text-sm uppercase tracking-widest">
             {stat.label}

--- a/src/app/(frontend)/miasta/_components/city-card.tsx
+++ b/src/app/(frontend)/miasta/_components/city-card.tsx
@@ -12,9 +12,9 @@ const CityCard: React.FC<CityCardProps> = ({ city, cinemasCount }) => {
     <li>
       <Link
         href={`/miasta/${city.slug}`}
-        className="group flex items-baseline justify-between gap-4 py-4 transition-colors duration-200 hover:text-blood-red focus-visible:text-blood-red focus-visible:outline-none"
+        className="group flex items-baseline justify-between gap-4 py-4 transition-colors duration-200 hover:text-white/70 focus-visible:text-white/70 focus-visible:outline-none"
       >
-        <span className="text-white text-lg md:text-xl font-semibold uppercase tracking-wide group-hover:text-blood-red group-focus-visible:text-blood-red transition-colors duration-200">
+        <span className="text-white text-lg md:text-xl font-semibold uppercase tracking-wide group-hover:text-white/70 group-focus-visible:text-white/70 transition-colors duration-200">
           {city.name}
         </span>
         <span className="text-neutral-600 text-sm shrink-0">

--- a/src/app/(frontend)/miasta/_components/city-link-item.tsx
+++ b/src/app/(frontend)/miasta/_components/city-link-item.tsx
@@ -12,9 +12,9 @@ const CityLinkItem: React.FC<CityLinkItemProps> = ({ city, cinemasCount }) => {
     <li>
       <Link
         href={`/miasta/${city.slug}`}
-        className="group flex items-baseline justify-between gap-4 py-3 transition-colors duration-200 hover:text-blood-red focus-visible:text-blood-red focus-visible:outline-none"
+        className="group flex items-baseline justify-between gap-4 py-3 transition-colors duration-200 hover:text-white focus-visible:text-white focus-visible:outline-none"
       >
-        <span className="text-neutral-300 text-base md:text-lg leading-snug group-hover:text-blood-red group-focus-visible:text-blood-red transition-colors duration-200">
+        <span className="text-neutral-300 text-base md:text-lg leading-snug group-hover:text-white group-focus-visible:text-white transition-colors duration-200">
           {city.name}
         </span>
 

--- a/src/app/(frontend)/seanse/_components/screenings-genre-tags.tsx
+++ b/src/app/(frontend)/seanse/_components/screenings-genre-tags.tsx
@@ -56,7 +56,7 @@ const ScreeningsGenreTags: React.FC<ScreeningsGenreTagsProps> = ({
         <button
           type="button"
           onClick={handleToggle}
-          className="inline-flex items-center gap-2 self-start px-3 py-1.5 text-xs uppercase tracking-widest text-white/70 hover:text-blood-red border border-white/15 hover:border-blood-red/50 transition-colors cursor-pointer mt-1"
+          className="inline-flex items-center gap-2 self-start px-3 py-1.5 text-xs uppercase tracking-widest text-white/70 hover:text-white border border-white/15 hover:border-white/50 transition-colors cursor-pointer mt-1"
         >
           {isExpanded ? (
             <>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -8,19 +8,6 @@
   --color-background: var(--background);
   --color-foreground: var(--foreground);
   --font-sans: var(--font-inter);
-  --color-sidebar-ring: var(--sidebar-ring);
-  --color-sidebar-border: var(--sidebar-border);
-  --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
-  --color-sidebar-accent: var(--sidebar-accent);
-  --color-sidebar-primary-foreground: var(--sidebar-primary-foreground);
-  --color-sidebar-primary: var(--sidebar-primary);
-  --color-sidebar-foreground: var(--sidebar-foreground);
-  --color-sidebar: var(--sidebar);
-  --color-chart-5: var(--chart-5);
-  --color-chart-4: var(--chart-4);
-  --color-chart-3: var(--chart-3);
-  --color-chart-2: var(--chart-2);
-  --color-chart-1: var(--chart-1);
   --color-ring: var(--ring);
   --color-input: var(--input);
   --color-border: var(--border);
@@ -29,14 +16,10 @@
   --color-accent: var(--accent);
   --color-muted-foreground: var(--muted-foreground);
   --color-muted: var(--muted);
-  --color-secondary-foreground: var(--secondary-foreground);
-  --color-secondary: var(--secondary);
   --color-primary-foreground: var(--primary-foreground);
   --color-primary: var(--primary);
   --color-popover-foreground: var(--popover-foreground);
   --color-popover: var(--popover);
-  --color-card-foreground: var(--card-foreground);
-  --color-card: var(--card);
   --radius-sm: calc(var(--radius) - 4px);
   --radius-md: calc(var(--radius) - 2px);
   --radius-lg: var(--radius);
@@ -53,26 +36,16 @@
   --font-bungee-shade: "Bungee Shade", sans-serif;
   --font-monoton: "Monoton", sans-serif;
   --font-oswald: "Oswald", sans-serif;
-  --color-banana-yellow: #ddd5b6;
-  --color-golden-yellow: #ddb956;
-  --color-blood-red: #dc1301;
-  --color-dark-ink: #121212;
-  /* Jeden akcent kuratorski: CTA, aktywne elementy, hover */
-  --color-accent-film: var(--color-blood-red);
 }
 
 :root {
   --radius: 0.625rem;
   --background: oklch(1 0 0);
   --foreground: oklch(0.141 0.005 285.823);
-  --card: oklch(1 0 0);
-  --card-foreground: oklch(0.141 0.005 285.823);
   --popover: oklch(1 0 0);
   --popover-foreground: oklch(0.141 0.005 285.823);
   --primary: oklch(0.21 0.006 285.885);
   --primary-foreground: oklch(0.985 0 0);
-  --secondary: oklch(0.967 0.001 286.375);
-  --secondary-foreground: oklch(0.21 0.006 285.885);
   --muted: oklch(0.967 0.001 286.375);
   --muted-foreground: oklch(0.552 0.016 285.938);
   --accent: oklch(0.967 0.001 286.375);
@@ -81,19 +54,6 @@
   --border: oklch(0.92 0.004 286.32);
   --input: oklch(0.92 0.004 286.32);
   --ring: oklch(0.705 0.015 286.067);
-  --chart-1: oklch(0.646 0.222 41.116);
-  --chart-2: oklch(0.6 0.118 184.704);
-  --chart-3: oklch(0.398 0.07 227.392);
-  --chart-4: oklch(0.828 0.189 84.429);
-  --chart-5: oklch(0.769 0.188 70.08);
-  --sidebar: oklch(0.985 0 0);
-  --sidebar-foreground: oklch(0.141 0.005 285.823);
-  --sidebar-primary: oklch(0.21 0.006 285.885);
-  --sidebar-primary-foreground: oklch(0.985 0 0);
-  --sidebar-accent: oklch(0.967 0.001 286.375);
-  --sidebar-accent-foreground: oklch(0.21 0.006 285.885);
-  --sidebar-border: oklch(0.92 0.004 286.32);
-  --sidebar-ring: oklch(0.705 0.015 286.067);
 }
 
 @layer base {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -6,6 +6,7 @@ import JsonLd from "@/components/common/json-ld";
 import SmoothScroll from "@/components/common/smooth-scroll";
 import CustomCursor from "@/components/common/custom-cursor";
 import ConsentBanner from "@/components/common/consent-banner";
+import WebVitalsReporter from "@/components/common/web-vitals-reporter";
 import { CityProvider } from "@/contexts/city-context";
 import { SOCIAL_PROFILE_URLS } from "@/constants";
 import { getCities } from "@/lib/cities";
@@ -128,6 +129,7 @@ export default async function RootLayout({
         <SmoothScroll />
         <CustomCursor />
         {process.env.GA_MEASUREMENT_ID && <ConsentBanner />}
+        {process.env.GA_MEASUREMENT_ID && <WebVitalsReporter />}
         <CityProvider cities={cities}>{children}</CityProvider>
       </body>
     </html>


### PR DESCRIPTION
## Summary

- Replace every `blood-red` hover, focus ring, and accent usage (buttons, badges, radio tags, links, cards, stats) with white or muted-white equivalents to complete the black-and-white redesign.
- Remove the now unused color tokens (`banana-yellow`, `golden-yellow`, `blood-red`, `dark-ink`, `accent-film`) and leftover shadcn variables (card, chart, sidebar, secondary) from `globals.css`.
- Add a `WebVitalsReporter` client component that forwards Core Web Vitals (LCP, INP, CLS, FCP, TTFB) to GA4 as events. Mounted only when GA is configured and a no-op until `gtag` exists, so nothing fires before analytics consent.