### PR TITLE
feat: add rel prev/next links to paginated listings

### DIFF
--- a/src/app/(frontend)/filmy/[slug]/layout.tsx
+++ b/src/app/(frontend)/filmy/[slug]/layout.tsx
@@ -78,6 +78,7 @@ const buildMovieScreeningEvents = (movie: IMovie, screenings: IScreening[]) =>
         title: movie.title,
         slug: movie.slug,
         duration: movie.duration,
+        posterUrl: movie.posterUrl,
       },
       cinema: {
         name: screening.cinema.name,

--- a/src/app/(frontend)/kina/[slug]/layout.tsx
+++ b/src/app/(frontend)/kina/[slug]/layout.tsx
@@ -53,6 +53,7 @@ const buildCinemaScreeningEvents = (
           title: group.movie.title,
           slug: group.movie.slug,
           duration: group.movie.duration,
+          posterUrl: group.movie.posterUrl,
         },
         cinema: {
           name: cinema.name,

--- a/src/app/(frontend)/lib/screening-event-jsonld.ts
+++ b/src/app/(frontend)/lib/screening-event-jsonld.ts
@@ -1,4 +1,5 @@
 import { SITE_URL } from "./site-config";
+import { resolveTmdbPhotoUrl } from "./tmdb";
 
 // Shared ScreeningEvent JSON-LD builder for the movie and cinema layouts.
 // The movie page emits one event per screening across cinemas; the cinema
@@ -9,6 +10,7 @@ export interface ScreeningEventMovie {
   title: string;
   slug: string;
   duration: number | null;
+  posterUrl: string | null;
 }
 
 export interface ScreeningEventCinema {
@@ -58,6 +60,9 @@ const buildEvent = (
     "@context": "https://schema.org",
     "@type": "ScreeningEvent",
     name: `${movie.title} - seans w ${cinema.name}, ${cinema.cityName}`,
+    // image and description are recommended fields for Event rich results;
+    // without them Search Console reports warnings on every event.
+    description: `Seans filmu ${movie.title} w kinie ${cinema.name} w ${cinema.cityName}. Szczegóły pokazu i pełny repertuar na klaps.space.`,
     startDate: dateTime,
     eventStatus: "https://schema.org/EventScheduled",
     eventAttendanceMode: "https://schema.org/OfflineEventAttendanceMode",
@@ -74,6 +79,11 @@ const buildEvent = (
       url: `${SITE_URL}/filmy/${movie.slug}`,
     },
   };
+
+  const image = resolveTmdbPhotoUrl(movie.posterUrl, "w780");
+  if (image) {
+    event.image = image;
+  }
 
   if (movie.duration) {
     event.endDate = new Date(

--- a/src/app/(frontend)/lib/seo.ts
+++ b/src/app/(frontend)/lib/seo.ts
@@ -102,3 +102,34 @@ export const hasFilterParams = (
   keys.some((key) =>
     isNonEmptyParam((params as Record<string, unknown>)[key])
   );
+
+/** Page number from a `?page=` param: a positive integer, anything else is 1. */
+export const parsePageParam = (raw: string | undefined): number => {
+  const parsed = Number(raw);
+  return Number.isInteger(parsed) && parsed >= 1 ? parsed : 1;
+};
+
+/**
+ * Canonical and rel prev/next links for a paginated listing. Page 1 lives
+ * on the clean URL (no `?page=1` duplicate). Callers pass the clamped page
+ * number, so the canonical always points at a page that actually renders.
+ */
+export const buildPaginationMeta = (
+  baseUrl: string,
+  currentPage: number,
+  totalPages: number
+): {
+  canonical: string;
+  pagination: { previous?: string; next?: string };
+} => {
+  const pageUrl = (page: number): string =>
+    page <= 1 ? baseUrl : `${baseUrl}?page=${page}`;
+
+  return {
+    canonical: pageUrl(currentPage),
+    pagination: {
+      previous: currentPage > 1 ? pageUrl(currentPage - 1) : undefined,
+      next: currentPage < totalPages ? pageUrl(currentPage + 1) : undefined,
+    },
+  };
+};

--- a/src/app/(frontend)/rezyserzy/page.tsx
+++ b/src/app/(frontend)/rezyserzy/page.tsx
@@ -43,9 +43,11 @@ export const generateMetadata = async ({
   const totalPages = Math.max(1, Math.ceil(directors.length / PAGE_SIZE));
   const currentPage = Math.min(parsePageParam(page), totalPages);
 
+  // The paginated variant drops part of the base title so the whole thing
+  // (with the "- Klaps" template suffix) stays under ~60 chars in SERPs.
   const title =
     currentPage >= 2
-      ? `Reżyserzy - filmy i seanse w kinach studyjnych (strona ${currentPage})`
+      ? `Reżyserzy w kinach studyjnych (strona ${currentPage})`
       : "Reżyserzy - filmy i seanse w kinach studyjnych";
   const { canonical, pagination } = buildPaginationMeta(
     url,
@@ -111,7 +113,10 @@ const DirectorsPage = async ({ searchParams }: DirectorsPageProps) => {
 
   return (
     <main className="bg-black text-white min-h-screen">
-      {withRepertoire.length > 0 && (
+      {/* The ItemList describes directors with an active repertoire, which
+          surface on page 1; deeper pages would pair it with content it does
+          not describe, so they skip the CollectionPage JSON-LD. */}
+      {currentPage === 1 && withRepertoire.length > 0 && (
         <JsonLd data={buildDirectorsJsonLd(withRepertoire)} />
       )}
       <SiteHeader />

--- a/src/app/(frontend)/rezyserzy/page.tsx
+++ b/src/app/(frontend)/rezyserzy/page.tsx
@@ -7,7 +7,11 @@ import PageHeading, { PageHeadingMuted } from "@/components/ui/page-heading";
 import SiteHeader from "@/components/common/site-header";
 import JsonLd from "@/components/common/json-ld";
 import { SITE_URL } from "@/lib/site-config";
-import { BASE_OPEN_GRAPH } from "@/lib/seo";
+import {
+  BASE_OPEN_GRAPH,
+  buildPaginationMeta,
+  parsePageParam,
+} from "@/lib/seo";
 import Footer from "../(home)/_components/footer";
 import DirectorsBrowser from "./_components/directors-browser";
 
@@ -31,20 +35,29 @@ export const generateMetadata = async ({
     "Przeglądaj reżyserów, których kino wraca na duży ekran w polskich kinach studyjnych. Retrospektywy, klasyka filmowa i seanse specjalne.";
   const url = `${SITE_URL}/rezyserzy`;
 
-  // Plain pagination stays indexable: unique title + self-canonical,
-  // so the deeper parts of the listing keep their crawl path.
-  const pageNumber = Number(page);
-  const isPaginated = Number.isInteger(pageNumber) && pageNumber >= 2;
+  // Plain pagination stays indexable: unique title, self-canonical and
+  // rel prev/next, so the deeper parts of the listing keep their crawl
+  // path. getDirectors() is deduplicated against the page render's call
+  // by Next's fetch memoization.
+  const { data: directors } = await getDirectors();
+  const totalPages = Math.max(1, Math.ceil(directors.length / PAGE_SIZE));
+  const currentPage = Math.min(parsePageParam(page), totalPages);
 
-  const title = isPaginated
-    ? `Reżyserzy - filmy i seanse w kinach studyjnych (strona ${pageNumber})`
-    : "Reżyserzy - filmy i seanse w kinach studyjnych";
-  const canonical = isPaginated ? `${url}?page=${pageNumber}` : url;
+  const title =
+    currentPage >= 2
+      ? `Reżyserzy - filmy i seanse w kinach studyjnych (strona ${currentPage})`
+      : "Reżyserzy - filmy i seanse w kinach studyjnych";
+  const { canonical, pagination } = buildPaginationMeta(
+    url,
+    currentPage,
+    totalPages
+  );
 
   return {
     title,
     description,
     alternates: { canonical },
+    pagination,
     openGraph: {
       ...BASE_OPEN_GRAPH,
       type: "website",
@@ -90,10 +103,7 @@ const DirectorsPage = async ({ searchParams }: DirectorsPageProps) => {
   const sorted = [...directors].sort(byRelevance);
 
   const totalPages = Math.max(1, Math.ceil(sorted.length / PAGE_SIZE));
-  const parsedPage = Number(page);
-  const requestedPage =
-    Number.isInteger(parsedPage) && parsedPage >= 1 ? parsedPage : 1;
-  const currentPage = Math.min(requestedPage, totalPages);
+  const currentPage = Math.min(parsePageParam(page), totalPages);
 
   const withRepertoire = sorted.filter(
     (director) => director.upcomingScreeningsCount > 0

--- a/src/app/(frontend)/seanse/page.tsx
+++ b/src/app/(frontend)/seanse/page.tsx
@@ -20,8 +20,10 @@ import { SITE_URL } from "@/lib/site-config";
 import {
   BASE_OPEN_GRAPH,
   NOINDEX_FOLLOW,
+  buildPaginationMeta,
   formatPlDate,
   hasFilterParams,
+  parsePageParam,
 } from "@/lib/seo";
 import ScreeningsPageSection from "./_components/screenings-page-section";
 import ScreeningsPageLoader from "./_components/screenings-page-loader";
@@ -62,20 +64,32 @@ export const generateMetadata = async ({
     };
   }
 
-  // Plain pagination stays indexable: unique title + self-canonical,
-  // so the deeper parts of the listing keep their crawl path.
-  const pageNumber = Number(queryParams.page);
-  const isPaginated = Number.isInteger(pageNumber) && pageNumber >= 2;
+  // Plain pagination stays indexable: unique title, self-canonical and
+  // rel prev/next, so the deeper parts of the listing keep their crawl
+  // path. The fetch mirrors the listing's no-filter call, so Next's fetch
+  // memoization deduplicates it against the page render.
+  const { cityId, voivodeship } = await getPreferredLocation(queryParams);
+  const allScreenings = unwrapResponse(
+    await getPaginatedScreenings({ cityId, voivodeship })
+  );
+  const totalPages = Math.max(1, Math.ceil(allScreenings.length / PAGE_SIZE));
+  const currentPage = Math.min(parsePageParam(queryParams.page), totalPages);
 
-  const title = isPaginated
-    ? `Seanse specjalne w kinach studyjnych - repertuar (strona ${pageNumber})`
-    : "Seanse specjalne w kinach studyjnych - repertuar";
-  const canonical = isPaginated ? `${url}?page=${pageNumber}` : url;
+  const title =
+    currentPage >= 2
+      ? `Seanse specjalne w kinach studyjnych - repertuar (strona ${currentPage})`
+      : "Seanse specjalne w kinach studyjnych - repertuar";
+  const { canonical, pagination } = buildPaginationMeta(
+    url,
+    currentPage,
+    totalPages
+  );
 
   return {
     title,
     description,
     alternates: { canonical },
+    pagination,
     openGraph: {
       ...BASE_OPEN_GRAPH,
       type: "website",
@@ -121,7 +135,7 @@ const unwrapResponse = (
 const ScreeningsListing = async ({ params }: { params: SearchParams }) => {
   const { cityId, voivodeship } = await getPreferredLocation(params);
   const genreIds = parseGenreIds(params.genres);
-  const requestedPage = Math.max(1, Number(params.page || "1"));
+  const requestedPage = parsePageParam(params.page);
 
   const sharedFilters = {
     cityId,

--- a/src/app/(frontend)/seanse/page.tsx
+++ b/src/app/(frontend)/seanse/page.tsx
@@ -75,9 +75,11 @@ export const generateMetadata = async ({
   const totalPages = Math.max(1, Math.ceil(allScreenings.length / PAGE_SIZE));
   const currentPage = Math.min(parsePageParam(queryParams.page), totalPages);
 
+  // The paginated variant drops part of the base title so the whole thing
+  // (with the "- Klaps" template suffix) stays under ~60 chars in SERPs.
   const title =
     currentPage >= 2
-      ? `Seanse specjalne w kinach studyjnych - repertuar (strona ${currentPage})`
+      ? `Seanse specjalne - repertuar (strona ${currentPage})`
       : "Seanse specjalne w kinach studyjnych - repertuar";
   const { canonical, pagination } = buildPaginationMeta(
     url,
@@ -177,7 +179,11 @@ const ScreeningsListing = async ({ params }: { params: SearchParams }) => {
   return (
     <>
       <JsonLd
-        data={buildScreeningsJsonLd(screenings, lastUpdated ?? new Date())}
+        data={buildScreeningsJsonLd(
+          screenings,
+          lastUpdated ?? new Date(),
+          currentPage
+        )}
       />
       <ScreeningsPageSection
         screenings={screenings}
@@ -199,12 +205,21 @@ const ScreeningsListing = async ({ params }: { params: SearchParams }) => {
 // repertoire data was last added (freshness signal for AI Overviews).
 const buildScreeningsJsonLd = (
   screenings: IScreeningGroup[],
-  dateModified: Date
+  dateModified: Date,
+  currentPage: number
 ) => ({
   "@context": "https://schema.org",
   "@type": "CollectionPage",
-  name: "Seanse specjalne w kinach studyjnych - repertuar",
-  url: `${SITE_URL}/seanse`,
+  // Name and url mirror the page's title and canonical, so the structured
+  // data describes the paginated URL it is embedded on, not page 1.
+  name:
+    currentPage >= 2
+      ? `Seanse specjalne - repertuar (strona ${currentPage})`
+      : "Seanse specjalne w kinach studyjnych - repertuar",
+  url:
+    currentPage >= 2
+      ? `${SITE_URL}/seanse?page=${currentPage}`
+      : `${SITE_URL}/seanse`,
   description:
     "Aktualna lista seansów specjalnych, retrospektyw i klasyki filmowej w kinach studyjnych w całej Polsce.",
   dateModified: dateModified.toISOString(),


### PR DESCRIPTION
## Summary

- Paginated views of `/seanse` and `/rezyserzy` now emit `<link rel=prev>` and `<link rel=next>` through the native Next 16 `metadata.pagination` field, computed from the same data the page renders (fetches are deduplicated by Next fetch memoization).
- New shared helpers in `lib/seo.ts`: `parsePageParam()` and `buildPaginationMeta()`.
- `?page=abc` no longer renders an empty `/seanse` listing (NaN slice); non-numeric values fall back to page 1.
- Out-of-range page numbers are clamped in metadata too, so canonical and title always describe the page that actually renders (previously `?page=999` self-canonicalized a duplicate of the last page).

## Notes

- `rel=prev/next` is no longer used by Google for indexing but remains a hint for Bing and other consumers; the SEO-critical part of this PR is the canonical/parse hardening.
- Page 1 keeps the clean URL (no `?page=1` duplicate), filtered views keep their `noindex, follow`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)