### PR TITLE
feat: link the director in the home hero, drop the duplicate on movie pages

### DIFF
--- a/src/app/(frontend)/(home)/_components/hero/index.tsx
+++ b/src/app/(frontend)/(home)/_components/hero/index.tsx
@@ -140,6 +140,8 @@ const Hero: React.FC<HeroProps> = ({ screening }) => {
     day: "2-digit",
     month: "long",
   }).format(screeningDate);
+  // Older API responses may omit the field, so default to no credit line.
+  const directors = screening.movie.directors ?? [];
 
   return (
     <section className="h-screen w-full bg-black flex items-center justify-center p-4 md:p-8">
@@ -212,6 +214,33 @@ const Hero: React.FC<HeroProps> = ({ screening }) => {
                       .map((g) => g.name)
                       .join(" / ")}
                   </span>
+                )}
+                {directors.length > 0 && (
+                  <>
+                    {(screening.movie.duration ||
+                      screening.movie.productionYear ||
+                      screening.movie.genres.length > 0) && (
+                      <span>&middot;</span>
+                    )}
+                    <span className="uppercase tracking-wider">
+                      Reż.{" "}
+                      {directors.map((person, index) => (
+                        <React.Fragment key={person.id ?? person.name}>
+                          {index > 0 && ", "}
+                          {person.slug ? (
+                            <Link
+                              href={`/rezyserzy/${person.slug}`}
+                              className="border-b border-white/30 hover:border-white hover:text-white transition-colors"
+                            >
+                              {person.name}
+                            </Link>
+                          ) : (
+                            person.name
+                          )}
+                        </React.Fragment>
+                      ))}
+                    </span>
+                  </>
                 )}
               </motion.div>
             </div>

--- a/src/app/(frontend)/filmy/[slug]/_components/movie-hero.tsx
+++ b/src/app/(frontend)/filmy/[slug]/_components/movie-hero.tsx
@@ -2,7 +2,6 @@
 
 import React, { useRef, useState } from "react";
 import Image from "next/image";
-import Link from "next/link";
 import { motion, useScroll, useTransform } from "framer-motion";
 import { Play } from "lucide-react";
 import { IMovie } from "@/interfaces/IMovies";
@@ -137,36 +136,8 @@ const MovieHero: React.FC<MovieHeroProps> = ({ movie }) => {
                 {movie.titleOriginal}
               </motion.span>
             )}
-            {movie.directors && movie.directors.length > 0 && (
-              <motion.span
-                variants={{
-                  hidden: { opacity: 0, y: 16 },
-                  visible: {
-                    opacity: 1,
-                    y: 0,
-                    transition: { duration: 0.5, ease: [0.22, 1, 0.36, 1] },
-                  },
-                }}
-                className="text-xs md:text-sm uppercase tracking-[0.25em] text-white/65"
-              >
-                <span className="text-white/45">Reżyseria</span>{" "}
-                {movie.directors.map((person, index) => (
-                  <React.Fragment key={person.id ?? person.name}>
-                    {index > 0 && ", "}
-                    {person.slug ? (
-                      <Link
-                        href={`/rezyserzy/${person.slug}`}
-                        className="border-b border-white/30 hover:border-white transition-colors"
-                      >
-                        {person.name}
-                      </Link>
-                    ) : (
-                      person.name
-                    )}
-                  </React.Fragment>
-                ))}
-              </motion.span>
-            )}
+            {/* Directors live in the "Informacje" credits below the fold,
+                so the hero skips them to avoid the duplicate. */}
             {movie.description && (
               <motion.p
                 variants={{

--- a/src/app/(frontend)/interfaces/IMovies.ts
+++ b/src/app/(frontend)/interfaces/IMovies.ts
@@ -37,6 +37,9 @@ export interface IMovieHero extends IMovieSummary {
   description: string | null;
   backdropUrl: string | null;
   videoUrl: string | null;
+  /** Sent only by endpoints that load the directors relation
+   * (e.g. /screenings/random-screening for the home hero). */
+  directors?: IMoviePerson[] | null;
 }
 
 export interface IMovieRatingScore {


### PR DESCRIPTION
## Summary

- The home hero meta line (duration, year, genres) now appends the director(s), linked to `/rezyserzy/[slug]` the same way the cinema and city are linked in the line above.
- Renders only when the API sends the new optional `directors` field on the random-screening movie hero, so it is safe to deploy before or after klaps-hq/api.klaps.space#57.
- The movie page hero drops its Rezyseria block; the same credit (with links) already lives in the Informacje section below the fold.

## Depends on

- klaps-hq/api.klaps.space#57 (the director only appears on the homepage once that API change is deployed; until then the hero renders exactly as today).

🤖 Generated with [Claude Code](https://claude.com/claude-code)