### PR TITLE
feat(cinemas): cinema website link + homepage performance

### DIFF
--- a/src/app/(frontend)/(home)/_components/hero/index.tsx
+++ b/src/app/(frontend)/(home)/_components/hero/index.tsx
@@ -170,14 +170,16 @@ const Hero: React.FC<HeroProps> = ({
       <h1 className="sr-only">
         Seanse specjalne i stare filmy w kinach studyjnych w Polsce
       </h1>
-      {/* "original" source: the optimizer downscales it to the viewport,
-          so the client payload stays small while the image is sharp on
-          large screens (w1280 upscaled looked soft). Originals are served
-          by the scraper-populated MinIO mirror, not the TMDB CDN. */}
+      {/* "w1280" source (not "original"): the hero is the LCP element, and
+          making the optimizer fetch+transcode a multi-MB original on a cache
+          miss (the hero rotates per revalidation) noticeably delayed the
+          image behind its blur placeholder. w1280 keeps the on-demand
+          transcode cheap and the optimizer still downscales it to the
+          viewport. Served by the scraper-populated MinIO mirror, not TMDB. */}
       <HeroParallax
         backdropSrc={tmdbImageSrc(
           screening.movie.backdropUrl ?? "",
-          "original"
+          "w1280"
         )}
         posterSrc={
           screening.movie.posterUrl

--- a/src/app/(frontend)/(home)/page.tsx
+++ b/src/app/(frontend)/(home)/page.tsx
@@ -46,9 +46,19 @@ const HomePage = async () => {
       <Suspense fallback={<ScreeningsLoader />}>
         <Screenings genres={genres} />
       </Suspense>
-      <Genres />
-      <Cinemas />
-      <Blog />
+      {/* Each below-the-fold section streams on its own so a slow data fetch
+          (e.g. the cinemas list) never blocks the hero shell or the others.
+          The page is statically prerendered, so crawlers still get the fully
+          baked HTML; the boundaries only matter on dev/revalidation renders. */}
+      <Suspense fallback={null}>
+        <Genres />
+      </Suspense>
+      <Suspense fallback={null}>
+        <Cinemas />
+      </Suspense>
+      <Suspense fallback={null}>
+        <Blog />
+      </Suspense>
       <About />
       <Footer />
     </>

--- a/src/app/(frontend)/interfaces/ICinema.ts
+++ b/src/app/(frontend)/interfaces/ICinema.ts
@@ -22,7 +22,10 @@ export interface ICinema {
   description: string | null;
   latitude: number | null;
   longitude: number | null;
-  sourceUrl: string;
+  // The cinema's listing on Filmweb (the catalog's source).
+  filmwebUrl: string;
+  // The cinema's own official website; null when unknown.
+  website: string | null;
 }
 
 export interface ICinemaGroup {

--- a/src/app/(frontend)/kina/[slug]/layout.tsx
+++ b/src/app/(frontend)/kina/[slug]/layout.tsx
@@ -33,8 +33,13 @@ const buildCinemaJsonLd = (cinema: ICinema) => {
     };
   }
 
-  if (cinema.sourceUrl) {
-    jsonLd.sameAs = cinema.sourceUrl;
+  // Tie the cinema entity to its presence elsewhere: its own website first,
+  // then the Filmweb listing the catalog is built from.
+  const sameAs = [cinema.website, cinema.filmwebUrl].filter(
+    (url): url is string => Boolean(url)
+  );
+  if (sameAs.length > 0) {
+    jsonLd.sameAs = sameAs;
   }
 
   return jsonLd;

--- a/src/app/(frontend)/kina/[slug]/page.tsx
+++ b/src/app/(frontend)/kina/[slug]/page.tsx
@@ -38,6 +38,11 @@ export const generateStaticParams = async (): Promise<{ slug: string }[]> => {
 
 const MAX_DESCRIPTION_LENGTH = 160;
 
+// Shared style for the small outbound links in the cinema header (official
+// site, Filmweb): subtle until hover, with a nudging arrow.
+const CINEMA_LINK_CLASS =
+  "group inline-flex items-center gap-1 text-white/70 hover:text-white transition-colors border-b border-transparent hover:border-white/40 pb-0.5";
+
 // Live repertoire counts and an example title make every cinema's
 // description unique, which improves SERP CTR and avoids the
 // boilerplate-description pattern across 500+ cinema pages.
@@ -129,6 +134,14 @@ const CinemaPageContent = async ({ slug }: { slug: string }) => {
   const hasCoordinates = cinema.latitude !== null && cinema.longitude !== null;
   const cityForCopy = cinema.city.nameDeclinated ?? cinema.city.name;
 
+  // Outbound links in the header: the cinema's own site (preferred) and its
+  // Filmweb listing. Followed links with a referrer are a trust signal and
+  // let cinemas notice klaps.space in their analytics.
+  const externalLinks = [
+    cinema.website && { href: cinema.website, label: "Strona kina" },
+    cinema.filmwebUrl && { href: cinema.filmwebUrl, label: "Filmweb" },
+  ].filter(Boolean) as { href: string; label: string }[];
+
   return (
     <>
       <div className="px-6 md:px-12 lg:px-16 pt-6 md:pt-8 pb-4">
@@ -158,27 +171,23 @@ const CinemaPageContent = async ({ slug }: { slug: string }) => {
                   </Link>
                   {cinema.city.voivodeship && <>, {cinema.city.voivodeship}</>}
                 </span>
-                {cinema.sourceUrl && (
-                  <>
+                {externalLinks.map((link) => (
+                  <React.Fragment key={link.href}>
                     <span aria-hidden="true">·</span>
-                    {/* Followed link with referrer: an editorial link to the
-                        cinema's official site is a trust signal, and the
-                        referrer lets cinemas notice klaps.space in their
-                        analytics (groundwork for reciprocal links). */}
                     <Link
-                      href={cinema.sourceUrl}
+                      href={link.href}
                       target="_blank"
                       rel="noopener"
-                      className="group inline-flex items-center gap-1 text-white/70 hover:text-white transition-colors border-b border-transparent hover:border-white/40 pb-0.5"
+                      className={CINEMA_LINK_CLASS}
                     >
-                      Strona kina
+                      {link.label}
                       <ArrowUpRight
                         aria-hidden="true"
                         className="size-3.5 shrink-0 transition-transform group-hover:translate-x-0.5 group-hover:-translate-y-0.5"
                       />
                     </Link>
-                  </>
-                )}
+                  </React.Fragment>
+                ))}
               </span>
             </div>
             {cinema.description ? (


### PR DESCRIPTION
## What

**Cinema website link**
- The cinema header now links out to the cinema's own website (new API `website` field) and to its Filmweb listing.
- Fixes a previously dead link: the page referenced `cinema.sourceUrl`, but the API returns `filmwebUrl`, so no link ever rendered. `ICinema` now matches the API (`filmwebUrl` + `website`) and the `MovieTheater` JSON-LD `sameAs` lists both URLs.

**Homepage performance**
- Wrap the Genres, Cinemas and Blog sections in `Suspense` so a slow data fetch (notably the cinemas list) no longer blocks the hero shell (LCP) or the other sections. The page is still statically prerendered, so crawlers get the fully baked HTML.
- Load the hero backdrop at `w1280` instead of `original`: forcing the image optimizer to fetch and transcode a multi-MB original on a cache miss (the hero rotates per revalidation) was delaying the LCP image behind its blur placeholder.

## Notes

- The `website` field is consumed defensively (`cinema.website && …`), so this is forward-compatible with the API: the link simply doesn't render until the API change ships.
- `tsc --noEmit`, `eslint` and `next build` all pass locally.

## Depends on

- API: `klaps-hq/api.klaps.space` PR #73 (adds the `website` column + exposes it in `GET /cinemas/:slug`).
