### PR TITLE
fix(cinemas): remove Filmweb from the site

### DIFF
--- a/src/app/(frontend)/filmy/[slug]/layout.tsx
+++ b/src/app/(frontend)/filmy/[slug]/layout.tsx
@@ -64,9 +64,7 @@ const buildMovieJsonLd = (movie: IMovie) => {
     };
   }
 
-  if (movie.filmwebUrl) {
-    jsonLd.sameAs = [movie.filmwebUrl];
-  }
+  // Filmweb is intentionally not referenced anywhere on the site.
 
   return jsonLd;
 };

--- a/src/app/(frontend)/kina/[slug]/layout.tsx
+++ b/src/app/(frontend)/kina/[slug]/layout.tsx
@@ -33,13 +33,10 @@ const buildCinemaJsonLd = (cinema: ICinema) => {
     };
   }
 
-  // Tie the cinema entity to its presence elsewhere: its own website first,
-  // then the Filmweb listing the catalog is built from.
-  const sameAs = [cinema.website, cinema.filmwebUrl].filter(
-    (url): url is string => Boolean(url)
-  );
-  if (sameAs.length > 0) {
-    jsonLd.sameAs = sameAs;
+  // Reference only the cinema's own official website. Filmweb is
+  // intentionally not exposed anywhere on the cinema page.
+  if (cinema.website) {
+    jsonLd.sameAs = cinema.website;
   }
 
   return jsonLd;

--- a/src/app/(frontend)/kina/[slug]/page.tsx
+++ b/src/app/(frontend)/kina/[slug]/page.tsx
@@ -134,13 +134,12 @@ const CinemaPageContent = async ({ slug }: { slug: string }) => {
   const hasCoordinates = cinema.latitude !== null && cinema.longitude !== null;
   const cityForCopy = cinema.city.nameDeclinated ?? cinema.city.name;
 
-  // Outbound links in the header: the cinema's own site (preferred) and its
-  // Filmweb listing. Followed links with a referrer are a trust signal and
-  // let cinemas notice klaps.space in their analytics.
-  const externalLinks = [
-    cinema.website && { href: cinema.website, label: "Strona kina" },
-    cinema.filmwebUrl && { href: cinema.filmwebUrl, label: "Filmweb" },
-  ].filter(Boolean) as { href: string; label: string }[];
+  // Outbound link in the header: the cinema's own website only. A followed
+  // link with a referrer is a trust signal and lets cinemas notice
+  // klaps.space in their analytics. Filmweb is intentionally NOT shown.
+  const externalLinks = (
+    cinema.website ? [{ href: cinema.website, label: "Strona kina" }] : []
+  ) as { href: string; label: string }[];
 
   return (
     <>


### PR DESCRIPTION
Filmweb must not appear on the page. Removes the visible Filmweb link on the cinema page and the Filmweb entry in both the cinema and movie JSON-LD sameAs. The cinema page now shows only the cinema's own website.