### PR TITLE
feat(cinemas): show full upcoming repertoire on the cinema page

### DIFF
--- a/src/app/(frontend)/kina/[slug]/layout.tsx
+++ b/src/app/(frontend)/kina/[slug]/layout.tsx
@@ -1,4 +1,4 @@
-import { getCinemaBySlug } from "@/lib/cinemas";
+import { getCinemaBySlug, cinemaRepertoireDateTo } from "@/lib/cinemas";
 import { getScreenings } from "@/lib/screenings";
 import { SITE_URL } from "@/lib/site-config";
 import { buildScreeningEventsJsonLd } from "@/lib/screening-event-jsonld";
@@ -82,6 +82,7 @@ export default async function CinemaLayout({
   // to [] internally, so a screenings hiccup never breaks the layout.
   const screeningGroups = await getScreenings({
     cinemaId: cinema.id.toString(),
+    dateTo: cinemaRepertoireDateTo(),
   });
 
   const events = buildCinemaScreeningEvents(cinema, screeningGroups);

--- a/src/app/(frontend)/kina/[slug]/page.tsx
+++ b/src/app/(frontend)/kina/[slug]/page.tsx
@@ -2,7 +2,12 @@ import React, { Suspense } from "react";
 import Link from "next/link";
 import { Metadata } from "next";
 import { ArrowUpRight } from "lucide-react";
-import { getCinemaPageData, getCinemaBySlug, getCinemas } from "@/lib/cinemas";
+import {
+  getCinemaPageData,
+  getCinemaBySlug,
+  getCinemas,
+  cinemaRepertoireDateTo,
+} from "@/lib/cinemas";
 import { getGenres } from "@/lib/genres";
 import { getScreenings } from "@/lib/screenings";
 import { SITE_URL } from "@/lib/site-config";
@@ -84,6 +89,7 @@ export const generateMetadata = async ({
   // Same call as the page body: deduped by the fetch cache.
   const screeningGroups = await getScreenings({
     cinemaId: cinema.id.toString(),
+    dateTo: cinemaRepertoireDateTo(),
   }).catch(() => []);
 
   // Locative city name ("w Krakowie", not "w Kraków") for natural phrasing.
@@ -129,6 +135,7 @@ const CinemaPageContent = async ({ slug }: { slug: string }) => {
   // client-side based on the URL params.
   const screenings = await getScreenings({
     cinemaId: cinema.id.toString(),
+    dateTo: cinemaRepertoireDateTo(),
   });
 
   const hasCoordinates = cinema.latitude !== null && cinema.longitude !== null;

--- a/src/app/(frontend)/lib/cinemas.ts
+++ b/src/app/(frontend)/lib/cinemas.ts
@@ -108,6 +108,13 @@ interface CinemaPageFilters {
   search?: string | null;
 }
 
+// Cinema detail pages show the venue's full upcoming programme, not just the
+// default 30-day window: partner cinemas submit schedules months ahead (e.g.
+// summer retrospectives), and the cinema page is where all of it belongs.
+// Listings and the homepage keep the 30-day default.
+export const cinemaRepertoireDateTo = (): string =>
+  new Date(Date.now() + 365 * 86_400_000).toISOString().slice(0, 10);
+
 export const getCinemaPageData = async (
   slug: string,
   filters: CinemaPageFilters = {}


### PR DESCRIPTION
The cinema detail page fetched only the default 30-day window, so a partner cinema's program months out (e.g. Kino Żak's July retrospective) wasn't visible. Pass a far dateTo (today + 365d) for the cinema page's screenings (repertoire + metadata + JSON-LD). Homepage and listings keep the 30-day default.