### PR TITLE
feat(hero): smooth blur placeholder and ken-burns drift

### DIFF
--- a/src/app/(frontend)/(home)/_components/hero/hero-parallax.tsx
+++ b/src/app/(frontend)/(home)/_components/hero/hero-parallax.tsx
@@ -2,7 +2,7 @@
 
 import React, { useRef } from "react";
 import { getImageProps } from "next/image";
-import { motion, useScroll, useTransform } from "framer-motion";
+import { motion, useScroll, useTransform, useReducedMotion } from "framer-motion";
 
 interface HeroParallaxProps {
   backdropSrc: string;
@@ -30,6 +30,7 @@ const HeroParallax: React.FC<HeroParallaxProps> = ({
   children,
 }) => {
   const ref = useRef<HTMLDivElement>(null);
+  const prefersReducedMotion = useReducedMotion();
   const { scrollYProgress } = useScroll({
     target: ref,
     offset: ["start start", "end start"],
@@ -78,42 +79,66 @@ const HeroParallax: React.FC<HeroParallaxProps> = ({
           style={{ y: imageY, scale: imageScale }}
         >
           {/* Blur previews live behind the <img> so each breakpoint gets its
-              own placeholder (a single img can only carry one blur style). */}
+              own placeholder (a single img can only carry one blur style).
+              blur + scale turns the tiny base64 preview into a smooth wash
+              instead of an upscaled pixel grid; scale-125 pushes the soft
+              edges of the filter past the (overflow-hidden) frame. */}
           {posterImageProps && posterBlurDataUrl && (
             <div
               aria-hidden="true"
-              className="absolute inset-0 bg-cover bg-center md:hidden"
+              className="absolute inset-0 bg-cover bg-center blur-2xl scale-125 md:hidden"
               style={{ backgroundImage: `url(${posterBlurDataUrl})` }}
             />
           )}
           {backdropBlurDataUrl && (
             <div
               aria-hidden="true"
-              className={`absolute inset-0 bg-cover bg-center ${
+              className={`absolute inset-0 bg-cover bg-center blur-2xl scale-125 ${
                 posterImageProps ? "hidden md:block" : ""
               }`}
               style={{ backgroundImage: `url(${backdropBlurDataUrl})` }}
             />
           )}
-          <picture>
-            {posterImageProps && (
-              <source
-                media={MOBILE_MEDIA}
-                srcSet={posterImageProps.srcSet}
-                sizes="100vw"
+          {/* Slow, continuous ken-burns drift on the artwork. It starts at
+              scale 1 (no opacity:0 / no initial), so the LCP hero image is
+              painted at full size from the first frame; the motion only adds
+              a gentle zoom afterwards. Skipped for prefers-reduced-motion. */}
+          <motion.div
+            className="absolute inset-0"
+            animate={
+              prefersReducedMotion ? undefined : { scale: [1, 1.08], y: ["0%", "-2.5%"] }
+            }
+            transition={
+              prefersReducedMotion
+                ? undefined
+                : {
+                    duration: 24,
+                    ease: "easeInOut",
+                    repeat: Infinity,
+                    repeatType: "reverse",
+                  }
+            }
+          >
+            <picture>
+              {posterImageProps && (
+                <source
+                  media={MOBILE_MEDIA}
+                  srcSet={posterImageProps.srcSet}
+                  sizes="100vw"
+                />
+              )}
+              {/* Raw img on purpose: props come from getImageProps, so the
+                  optimizer pipeline still applies (alt included via spread).
+                  Explicit fetchPriority: getImageProps does not forward it,
+                  and Lighthouse flags the LCP image without the hint. */}
+              {/* eslint-disable-next-line jsx-a11y/alt-text */}
+              <img
+                {...backdropProps}
+                fetchPriority="high"
+                className="object-cover"
               />
-            )}
-            {/* Raw img on purpose: props come from getImageProps, so the
-                optimizer pipeline still applies (alt included via spread).
-                Explicit fetchPriority: getImageProps does not forward it,
-                and Lighthouse flags the LCP image without the hint. */}
-            {/* eslint-disable-next-line jsx-a11y/alt-text */}
-            <img
-              {...backdropProps}
-              fetchPriority="high"
-              className="object-cover"
-            />
-          </picture>
+            </picture>
+          </motion.div>
         </motion.div>
       </div>
 


### PR DESCRIPTION
## Problem

The homepage hero rendered the base64 blur preview as a plain `bg-cover`
div, so the tiny image was upscaled into a visible pixel grid (the "ugly
blur" the change set out to fix).

## Change

- Apply a CSS blur (`blur-2xl`) + `scale-125` to both placeholder layers
  (mobile poster / desktop backdrop), turning the tiny preview into a
  smooth wash. The scale pushes the soft filter edges past the
  `overflow-hidden` frame so no halo is visible.
- Wrap the artwork in a slow, continuous ken-burns zoom (24s, scale
  1 -> 1.08 with a slight vertical drift), disabled for
  `prefers-reduced-motion`. It starts at scale 1 so the LCP hero image is
  painted at full size from the first frame (no `opacity: 0` / initial).

## Notes

Frontend-only change in a client component. `lint` and `tsc --noEmit`
pass. Local `next build` could not complete end-to-end (it prerenders
against the API/DB, unavailable locally), so verify the visual result on
a running environment.
